### PR TITLE
Show screenshare track when camera is disabled

### DIFF
--- a/src/components/MainParticipantInfo/MainParticipantInfo.test.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.test.tsx
@@ -11,22 +11,6 @@ jest.mock('../../hooks/usePublications/usePublications');
 const mockUsePublications = usePublications as jest.Mock<any>;
 
 describe('the MainParticipantInfo component', () => {
-  it('should add hideVideoProp to InfoContainer component when video is disabled', () => {
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera', isTrackEnabled: false }]);
-    const wrapper = shallow(
-      <MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>
-    );
-    expect(wrapper.find(InfoContainer).prop('hideVideo')).toEqual(true);
-  });
-
-  it('should not add hideVideoProp to InfoContainer component when video is enabled', () => {
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera', isTrackEnabled: true }]);
-    const wrapper = shallow(
-      <MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>
-    );
-    expect(wrapper.find(InfoContainer).prop('hideVideo')).toEqual(false);
-  });
-
   it('should render a VideoCamOff icon when no camera tracks are present', () => {
     mockUsePublications.mockImplementation(() => []);
     const wrapper = shallow(

--- a/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -12,16 +12,13 @@ const Container = styled('div')({
   alignItems: 'center',
 });
 
-export const InfoContainer = styled(({ hideVideo, ...otherProps }: { hideVideo?: boolean }) => <div {...otherProps} />)(
-  {
-    position: 'absolute',
-    zIndex: 1,
-    height: '100%',
-    padding: '0.4em',
-    width: '100%',
-    background: ({ hideVideo }) => (hideVideo ? 'black' : 'transparent'),
-  }
-);
+export const InfoContainer = styled('div')({
+  position: 'absolute',
+  zIndex: 1,
+  height: '100%',
+  padding: '0.4em',
+  width: '100%',
+});
 
 const Identity = styled('h4')({
   background: 'rgba(0, 0, 0, 0.7)',
@@ -45,7 +42,7 @@ export default function ParticipantInfo({ participant, children }: ParticipantIn
 
   return (
     <Container>
-      <InfoContainer hideVideo={!isVideoEnabled}>
+      <InfoContainer>
         <Identity>
           {participant.identity}
           {!isVideoEnabled && <VideocamOff />}


### PR DESCRIPTION


**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-154](https://issues.corp.twilio.com/browse/AHOYAPPS-154)

### Description

This PR removes the black layer that is displayed in the main video area when a user's camera is disabled.  It was blocking the user's screen share track.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary