### PR TITLE
Add Twilio build variant to apple-app-site-association

### DIFF
--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -1,9 +1,14 @@
 {
-    "applinks": {
-        "apps": [],
-        "details": [{
-            "appID": "SX5J6BN2KX.com.twilio.video-app-internal",
-            "paths": ["/room/*"]
-        }]
-    }
+	"applinks": {
+		"apps": [],
+		"details": [{
+				"appID": "SX5J6BN2KX.com.twilio.video-app",
+				"paths": ["/room/*"]
+			},
+			{
+				"appID": "SX5J6BN2KX.com.twilio.video-app-internal",
+				"paths": ["/room/*"]
+			}
+		]
+	}
 }


### PR DESCRIPTION
@paynerc realized we need to add more to this file to make both `Video-Internal` and `Video-Twilio` build variants work.