### PR TITLE
Fix crash for devices not supporting getDisplayMedia

### DIFF
--- a/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.test.tsx
+++ b/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.test.tsx
@@ -5,7 +5,12 @@ import useScreenShareParticipant from '../../../hooks/useScreenShareParticipant/
 import useScreenShareToggle from '../../../hooks/useScreenShareToggle/useScreenShareToggle';
 import useVideoContext from '../../../hooks/useVideoContext/useVideoContext';
 
-import ToggleScreenShareButton from './ToggleScreenShareButton';
+import ToggleScreenShareButton, {
+  SCREEN_SHARE_TEXT,
+  STOP_SCREEN_SHARE_TEXT,
+  SHARE_IN_PROGRESS_TEXT,
+  SHARE_NOT_SUPPORTED_TEXT,
+} from './ToggleScreenShareButton';
 
 jest.mock('../../../hooks/useScreenShareToggle/useScreenShareToggle');
 jest.mock('../../../hooks/useScreenShareParticipant/useScreenShareParticipant');
@@ -29,14 +34,14 @@ describe('the ToggleScreenShareButton component', () => {
     mockUseScreenShareToggle.mockImplementation(() => [false, () => {}]);
     const wrapper = shallow(<ToggleScreenShareButton />);
     expect(wrapper.find('ScreenShareIcon').exists()).toBe(true);
-    expect(wrapper.prop('title')).toBe('Share Screen');
+    expect(wrapper.prop('title')).toBe(SCREEN_SHARE_TEXT);
   });
 
   it('should render correctly when the user is sharing their screen', () => {
     mockUseScreenShareToggle.mockImplementation(() => [true, () => {}]);
     const wrapper = shallow(<ToggleScreenShareButton />);
     expect(wrapper.find('StopScreenShareIcon').exists()).toBe(true);
-    expect(wrapper.prop('title')).toBe('Stop Sharing Screen');
+    expect(wrapper.prop('title')).toBe(STOP_SCREEN_SHARE_TEXT);
   });
 
   it('should render correctly when another user is sharing their screen', () => {
@@ -44,7 +49,7 @@ describe('the ToggleScreenShareButton component', () => {
     mockUseScreenShareToggle.mockImplementation(() => [false, () => {}]);
     const wrapper = shallow(<ToggleScreenShareButton />);
     expect(wrapper.find('WithStyles(ForwardRef(Fab))').prop('disabled')).toBe(true);
-    expect(wrapper.prop('title')).toBe('Cannot share screen when another user is sharing');
+    expect(wrapper.prop('title')).toBe(SHARE_IN_PROGRESS_TEXT);
   });
 
   it('should call the correct toggle function when clicked', () => {
@@ -55,10 +60,11 @@ describe('the ToggleScreenShareButton component', () => {
     expect(mockFn).toHaveBeenCalled();
   });
 
-  it('should not render the screenshare button if screensharing is not supported', () => {
+  it('should render the screenshare button with the correct messaging if screensharing is not supported', () => {
     Object.defineProperty(navigator, 'mediaDevices', { value: { getDisplayMedia: undefined } });
     const wrapper = shallow(<ToggleScreenShareButton />);
-    expect(wrapper.find('ScreenShareIcon').exists()).toBe(false);
-    expect(wrapper.find('StopScreenShareIcon').exists()).toBe(false);
+    expect(wrapper.find('ScreenShareIcon').exists()).toBe(true);
+    expect(wrapper.find('WithStyles(ForwardRef(Fab))').prop('disabled')).toBe(true);
+    expect(wrapper.prop('title')).toBe(SHARE_NOT_SUPPORTED_TEXT);
   });
 });

--- a/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.tsx
+++ b/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.tsx
@@ -55,7 +55,7 @@ export default function ToggleScreenShareButton(props: { disabled?: boolean }) {
       title={tooltipMessage}
       placement="top"
       PopperProps={{ disablePortal: true }}
-      style={{ cursor: isDisabled ? 'not-allowed' : '' }}
+      style={{ cursor: isDisabled ? 'not-allowed' : 'pointer' }}
     >
       <div>
         {/* The div element is needed because a disabled button will not emit hover events and we want to display

--- a/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.tsx
+++ b/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.tsx
@@ -28,28 +28,37 @@ export default function ToggleScreenShareButton(props: { disabled?: boolean }) {
   const screenShareParticipant = useScreenShareParticipant();
   const { room } = useVideoContext();
   const disableScreenShareButton = screenShareParticipant && screenShareParticipant !== room.localParticipant;
-  const tooltipMessage = isScreenShared ? 'Stop Sharing Screen' : 'Share Screen';
+  const screenShareIsSupported = navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia;
+  const isDisabled = props.disabled || disableScreenShareButton || !screenShareIsSupported;
+
+  let tooltipMessage = 'Share Screen';
+
+  if (isScreenShared) {
+    tooltipMessage = 'Stop Sharing Screen';
+  }
+
+  if (disableScreenShareButton) {
+    tooltipMessage = 'Cannot share screen when another user is sharing';
+  }
+
+  if (!screenShareIsSupported) {
+    tooltipMessage = 'Screen sharing is not supported with this browser';
+  }
 
   return (
-    navigator.mediaDevices &&
-    navigator.mediaDevices.getDisplayMedia && (
-      <Tooltip
-        title={disableScreenShareButton ? 'Cannot share screen when another user is sharing' : tooltipMessage}
-        placement="top"
-        PopperProps={{ disablePortal: true }}
-      >
-        <div>
-          {/* The div element is needed because a disabled button will not emit hover events and we want to display
-            a tooltip when screen sharing is disabled */}
-          <Fab
-            className={classes.fab}
-            onClick={toggleScreenShare}
-            disabled={props.disabled || disableScreenShareButton}
-          >
-            {isScreenShared ? <StopScreenShare /> : <ScreenShare />}
-          </Fab>
-        </div>
-      </Tooltip>
-    )
+    <Tooltip
+      title={tooltipMessage}
+      placement="top"
+      PopperProps={{ disablePortal: true }}
+      style={{ cursor: isDisabled ? 'not-allowed' : '' }}
+    >
+      <div>
+        {/* The div element is needed because a disabled button will not emit hover events and we want to display
+          a tooltip when screen sharing is disabled */}
+        <Fab className={classes.fab} onClick={toggleScreenShare} disabled={isDisabled}>
+          {isScreenShared ? <StopScreenShare /> : <ScreenShare />}
+        </Fab>
+      </div>
+    </Tooltip>
   );
 }

--- a/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.tsx
+++ b/src/components/Controls/ToogleScreenShareButton/ToggleScreenShareButton.tsx
@@ -10,6 +10,11 @@ import useScreenShareToggle from '../../../hooks/useScreenShareToggle/useScreenS
 import useScreenShareParticipant from '../../../hooks/useScreenShareParticipant/useScreenShareParticipant';
 import useVideoContext from '../../../hooks/useVideoContext/useVideoContext';
 
+export const SCREEN_SHARE_TEXT = 'Share Screen';
+export const STOP_SCREEN_SHARE_TEXT = 'Stop Sharing Screen';
+export const SHARE_IN_PROGRESS_TEXT = 'Cannot share screen when another user is sharing';
+export const SHARE_NOT_SUPPORTED_TEXT = 'Screen sharing is not supported with this browser';
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     fab: {
@@ -31,18 +36,18 @@ export default function ToggleScreenShareButton(props: { disabled?: boolean }) {
   const screenShareIsSupported = navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia;
   const isDisabled = props.disabled || disableScreenShareButton || !screenShareIsSupported;
 
-  let tooltipMessage = 'Share Screen';
+  let tooltipMessage = SCREEN_SHARE_TEXT;
 
   if (isScreenShared) {
-    tooltipMessage = 'Stop Sharing Screen';
+    tooltipMessage = STOP_SCREEN_SHARE_TEXT;
   }
 
   if (disableScreenShareButton) {
-    tooltipMessage = 'Cannot share screen when another user is sharing';
+    tooltipMessage = SHARE_IN_PROGRESS_TEXT;
   }
 
   if (!screenShareIsSupported) {
-    tooltipMessage = 'Screen sharing is not supported with this browser';
+    tooltipMessage = SHARE_NOT_SUPPORTED_TEXT;
   }
 
   return (


### PR DESCRIPTION
When trying to run the demo app in Safari desktop < v13 and on iOS ipad and iphone (any device that does not support getDisplayMedia is affected) we came across an issue when you join a room. 
Upon joining the room the app crashes and leaves a blank screen and an unrecoverable state for the user. Other users in the same room would still see the video stream and receive audio from this user though. 

The error thrown is a React 152 error which means a component is not rendering anything at all.

Updated the ToggleScreenShareButton messaging to inform the user that they cannot share their screen due to browser support and also made sure that a message is always shown. I think this is probably better than just hiding the screenshare button altogether for a demo app.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary N/A
* [x] Added unit tests if necessary
* [ ] Updated affected documentation N/A
* [x] Verified locally with `npm test` 
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed) N/A
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary