### PR TITLE
room name and user name as GET parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint-staged": "^9.5.0",
     "lodash.throttle": "^4.1.1",
     "prettier": "^1.19.1",
+    "query-string": "^6.11.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",

--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -42,7 +42,14 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function MenuBar() {
   const classes = useStyles();
-  const { URLRoomName } = useParams();
+  let { URLRoomName } = useParams();
+
+  if (!URLRoomName) {
+    URLRoomName = window.sessionStorage.getItem('room') || '';
+  }
+
+  const URLUserName = window.sessionStorage.getItem('user') || '';
+
   const { user, getToken } = useAppState();
   const { isConnecting, connect } = useVideoContext();
   const roomState = useRoomState();
@@ -54,7 +61,15 @@ export default function MenuBar() {
     if (URLRoomName) {
       setRoomName(URLRoomName);
     }
-  }, [URLRoomName]);
+
+    if (URLUserName) {
+      setName(URLUserName);
+    }
+
+    if (URLRoomName && URLUserName) {
+      getToken(URLUserName, URLRoomName).then(token => connect(token));
+    }
+  }, [URLRoomName, URLUserName]);
 
   const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setName(event.target.value);

--- a/src/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -1,9 +1,22 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+const queryString = require('query-string');
+
+export function getRoomName() {
+  const parsed = queryString.parse(window.location.search);
+  const room = parsed.room ? parsed.room : window.sessionStorage.getItem('room');
+  return room;
+}
+
+export function getUserName() {
+  const parsed = queryString.parse(window.location.search);
+  const user = parsed.user ? parsed.user : window.sessionStorage.getItem('user');
+  return user;
+}
 
 export function getPasscode() {
-  const match = window.location.search.match(/passcode=(.*)&?/);
-  const passcode = match ? match[1] : window.sessionStorage.getItem('passcode');
+  const parsed = queryString.parse(window.location.search);
+  const passcode = parsed.passcode ? parsed.passcode : window.sessionStorage.getItem('passcode');
   return passcode;
 }
 
@@ -58,6 +71,8 @@ export default function usePasscodeAuth() {
 
   useEffect(() => {
     const passcode = getPasscode();
+    const room = getRoomName();
+    const user = getUserName();
 
     if (passcode) {
       verifyPasscode(passcode)
@@ -65,6 +80,15 @@ export default function usePasscodeAuth() {
           if (verification?.isValid) {
             setUser({ passcode } as any);
             window.sessionStorage.setItem('passcode', passcode);
+
+            if (user) {
+              window.sessionStorage.setItem('user', user);
+            }
+
+            if (room) {
+              window.sessionStorage.setItem('room', room);
+            }
+
             history.replace(window.location.pathname);
           }
         })
@@ -79,6 +103,17 @@ export default function usePasscodeAuth() {
       if (verification?.isValid) {
         setUser({ passcode } as any);
         window.sessionStorage.setItem('passcode', passcode);
+
+        const room = getRoomName();
+        const user = getUserName();
+
+        if (user) {
+          window.sessionStorage.setItem('user', user);
+        }
+
+        if (room) {
+          window.sessionStorage.setItem('room', room);
+        }
       } else {
         throw new Error(getErrorMessage(verification?.error));
       }


### PR DESCRIPTION
This feature allows users to pass in the room name and user name as GET parameters to the application. This enables `<iframe>` embeds as well as easier link sharing to get multiple participants into the same room.

Example URL: https://video-app-XXXX-dev.twil.io/?passcode=NNNNNNNNN&room=my-room&user=admin

I know that the room name can be passed in via URL route, however this does not work when deployed to Twilio Functions API infrastructure. 

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary