### PR TITLE
Correct app delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ View the URL and passcode for the Video app with
 
 Delete the app with
 
-    $ twilio rtc:apps:delete
+    $ twilio rtc:apps:video:delete
 
 This removes the Serverless app from Twilio. This will ensure that no further cost are incurred by the app.
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-0000](https://issues.corp.twilio.com/browse/AHOYAPPS-0000)

### Description

The readme contained an incorrect delete command, this should be twilio rtc:apps:video:delete

## Burndown

### Before review
* [x ] Updated CHANGELOG.md if necessary
* [x ] Added unit tests if necessary
* [ x] Updated affected documentation
* [x ] Verified locally with `npm test`
* [x ] Manually sanity tested running locally
* [x ] Included screenshot as PR comment (if needed)
* [x ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [x ] Re-tested if necessary