### PR TITLE
Improve passcode error handling

### DIFF
--- a/src/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -50,6 +50,14 @@ export default function usePasscodeAuth() {
   const getToken = useCallback(
     (name: string, room: string) => {
       return fetchToken(name, room, user!.passcode)
+        .then(async res => {
+          if (res.ok) {
+            return res;
+          }
+          const json = await res.json();
+          const errorMessage = getErrorMessage(json.error?.message || res.statusText);
+          throw Error(errorMessage);
+        })
         .then(res => res.json())
         .then(res => res.token as string);
     },


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-454](https://issues.corp.twilio.com/browse/AHOYAPPS-454)

### Description

This PR improves error handling for passcode auth. It handles the rare case when the user visits the Twilio Serverless URL before it expires, but then tries to join a room after it expires. It displays the same error messages that are seen on the passcode login screen.

![image](https://user-images.githubusercontent.com/12685223/77557122-fe52df00-6e7e-11ea-8b7e-7443bb7b63b9.png)


## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary