### PR TITLE
Take visualViewport.scale into account when determining height of window

### DIFF
--- a/src/hooks/useHeight/useHeight.test.tsx
+++ b/src/hooks/useHeight/useHeight.test.tsx
@@ -17,4 +17,25 @@ describe('the useHeight hook', () => {
 
     expect(result.current).toBe('150px');
   });
+
+  it('should take window.visualViewport.scale into account', () => {
+    // @ts-ignore
+    window.innerHeight = 100;
+
+    // @ts-ignore
+    window.visualViewport = {
+      scale: 2,
+    };
+
+    const { result } = renderHook(useHeight);
+    expect(result.current).toBe('200px');
+
+    act(() => {
+      // @ts-ignore
+      window.innerHeight = 150;
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current).toBe('300px');
+  });
 });

--- a/src/hooks/useHeight/useHeight.ts
+++ b/src/hooks/useHeight/useHeight.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 
 export default function useHeight() {
-  const [height, setHeight] = useState(window.innerHeight);
+  const [height, setHeight] = useState(window.innerHeight * (window.visualViewport?.scale || 1));
 
   useEffect(() => {
     const onResize = () => {
-      setHeight(window.innerHeight);
+      setHeight(window.innerHeight * (window.visualViewport?.scale || 1));
     };
 
     window.addEventListener('resize', onResize);

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,12 @@ declare module 'twilio-video' {
 }
 
 declare global {
+  interface Window {
+    visualViewport?: {
+      scale: number;
+    };
+  }
+
   interface MediaDevices {
     getDisplayMedia(constraints: MediaStreamConstraints): Promise<MediaStream>;
   }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-606](https://issues.corp.twilio.com/browse/AHOYAPPS-606)

### Description

This PR fixes a pinch-to-zoom issue in iOS Safari. When the user pinches to zoom in, the browser occasionally fires a `resize` event. Since the height of the app's main container is set dynamically with JS, these `resize` events break the layout because `window.innerHeight` shrinks as the user zooms in. 

This PR updates `useHeight` so that it takes the viewport's scale into account. This makes pinch-to-zoom work properly because the figure reported by `useHeight` will always stay the same as the user zooms:

innerHeight: 200 * scale: 1 = 200 
innerHeight: 100 * scale: 2 = 200
innerHeight: 50 * scale: 4 = 200


## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary