### PR TITLE
Fix cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12-latest-browsers
+      - image: circleci/node:12-browsers
     working_directory: ~/twilio-video-react-app
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:12-latest-browsers
     working_directory: ~/twilio-video-react-app
 
     steps:

--- a/cypress/integration/twilio-video.spec.js
+++ b/cypress/integration/twilio-video.spec.js
@@ -18,7 +18,7 @@ context('A video app user', () => {
         .should('be', 21);
       cy.get('clipPath rect')
         .invoke('attr', 'y')
-        .should('be.lessThan', 20);
+        .should('be.lessThan', 21);
     });
   });
 
@@ -57,7 +57,7 @@ context('A video app user', () => {
         .should('be', 21);
       cy.get('clipPath rect')
         .invoke('attr', 'y')
-        .should('be.lessThan', 20);
+        .should('be.lessThan', 21);
     });
 
     it('should see other participants disconnect when they close their browser', () => {

--- a/cypress/integration/twilio-video.spec.js
+++ b/cypress/integration/twilio-video.spec.js
@@ -46,7 +46,7 @@ context('A video app user', () => {
         .shouldBeSameVideoAs('[data-cy-main-participant]');
     });
 
-    it.skip('should be able to hear the other participant', () => {
+    it('should be able to hear the other participant', () => {
       cy.getParticipant('test1').shouldBeMakingSound();
     });
 
@@ -86,7 +86,7 @@ context('A video app user', () => {
         .shouldBeSameVideoAs('[data-cy-main-participant]');
     });
 
-    it.skip('should be able to hear the other participant', () => {
+    it('should be able to hear the other participant', () => {
       cy.getParticipant('test1').shouldBeMakingSound();
     });
   });
@@ -117,7 +117,7 @@ context('A video app user', () => {
         .shouldBeColor('green');
     });
 
-    it.skip('should be able to hear the other participants', () => {
+    it('should be able to hear the other participants', () => {
       cy.getParticipant('test1').shouldBeMakingSound();
       cy.getParticipant('test2').shouldBeMakingSound();
       cy.getParticipant('test3').shouldBeMakingSound();
@@ -150,7 +150,7 @@ context('A video app user', () => {
         .shouldBeColor('green');
     });
 
-    it.skip('should be able to hear the other participants', () => {
+    it('should be able to hear the other participants', () => {
       cy.getParticipant('test1').shouldBeMakingSound();
       cy.getParticipant('test2').shouldBeMakingSound();
       cy.getParticipant('test3').shouldBeMakingSound();

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,6 +1,19 @@
 const puppeteer = require('puppeteer');
 const participants = {};
 
+let browser;
+const args = ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'];
+
+async function init() {
+  if (!browser) {
+    browser = await puppeteer.launch({
+      headless: true,
+      args,
+    });
+  }
+  return Promise.resolve(null)
+}
+
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing).
 // `on` is used to hook into various events Cypress emits
@@ -8,16 +21,12 @@ const participants = {};
 module.exports = (on, config) => {
   const participantFunctions = {
     addParticipant: async ({ name, roomName, color }) => {
-      const args = ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'];
+      await init();
 
       if (color) {
         args.push(`--use-file-for-fake-video-capture=cypress/fixtures/${color}.y4m`);
       }
 
-      const browser = await puppeteer.launch({
-        headless: true,
-        args,
-      });
       const page = (participants[name] = await browser.newPage()); // keep track of this participant for future use
       await page.goto(config.baseUrl);
       await page.type('#menu-name', name);

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,19 +1,6 @@
 const puppeteer = require('puppeteer');
 const participants = {};
 
-let browser;
-const args = ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'];
-
-async function init() {
-  if (!browser) {
-    browser = await puppeteer.launch({
-      headless: true,
-      args,
-    });
-  }
-  return Promise.resolve(null)
-}
-
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing).
 // `on` is used to hook into various events Cypress emits
@@ -21,12 +8,16 @@ async function init() {
 module.exports = (on, config) => {
   const participantFunctions = {
     addParticipant: async ({ name, roomName, color }) => {
-      await init();
+      const args = ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'];
 
       if (color) {
         args.push(`--use-file-for-fake-video-capture=cypress/fixtures/${color}.y4m`);
       }
 
+      const browser = await puppeteer.launch({
+        headless: true,
+        args,
+      });
       const page = (participants[name] = await browser.newPage()); // keep track of this participant for future use
       await page.goto(config.baseUrl);
       await page.type('#menu-name', name);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,6 +37,14 @@ Cypress.Commands.add('shouldBeSameVideoAs', { prevSubject: 'element' }, (subject
 
 Cypress.Commands.add('getParticipant', name => cy.get(`[data-cy-participant="${name}"]`));
 
+function getParticipantAudioTrackName(name, window) {
+  const participant = Array.from(window.twilioRoom.participants.values()).find(
+    participant => participant.identity === name
+  );
+  const audioTrack = Array.from(participant.audioTracks.values())[0].track;
+  return audioTrack.name;
+}
+
 Cypress.Commands.add('shouldBeMakingSound', { prevSubject: 'element' }, subject => {
   const resolveValue = $el =>
     detectSound($el[0]).then(value => {
@@ -48,9 +56,13 @@ Cypress.Commands.add('shouldBeMakingSound', { prevSubject: 'element' }, subject 
         }
       );
     });
-
-  cy.wrap(subject)
-    .find('audio')
+    
+  cy.window()
+    .then(win => {
+      const participantIdentity = subject.attr('data-cy-participant');
+      const trackName = getParticipantAudioTrackName(participantIdentity, win);
+      return win.document.querySelector(`[data-cy-audio-track-name="${trackName}"]`);
+    })
     .then(resolveValue)
     .should('equal', true);
 });

--- a/src/components/AudioTrack/AudioTrack.tsx
+++ b/src/components/AudioTrack/AudioTrack.tsx
@@ -12,6 +12,7 @@ export default function AudioTrack({ track }: AudioTrackProps) {
 
   useEffect(() => {
     audioEl.current = track.attach();
+    audioEl.current.setAttribute('data-cy-audio-track-name', track.name);
     document.body.appendChild(audioEl.current);
     return () => track.detach().forEach(el => el.remove());
   }, [track]);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

A while back, we changed the way that the AudioTrack component renders `<audio>` elements. This was done to try and fix a Safari bug, so we merged the change quickly and disabled the Cypress tests that broke. 

This PR re-enables those Cypress tests. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary