### PR TITLE
Fix useIsTrackEnabled

### DIFF
--- a/src/hooks/useIsTrackEnabled/useIsTrackEnabled.test.tsx
+++ b/src/hooks/useIsTrackEnabled/useIsTrackEnabled.test.tsx
@@ -9,9 +9,9 @@ describe('the useIsTrackEnabled hook', () => {
     mockTrack = new EventEmitter();
   });
 
-  it('should return true when track is undefined', () => {
+  it('should return false when track is undefined', () => {
     const { result } = renderHook(() => useIsTrackEnabled(undefined));
-    expect(result.current).toBe(true);
+    expect(result.current).toBe(false);
   });
 
   it('should return mockTrack.isEnabled by default', () => {

--- a/src/hooks/useIsTrackEnabled/useIsTrackEnabled.tsx
+++ b/src/hooks/useIsTrackEnabled/useIsTrackEnabled.tsx
@@ -4,10 +4,10 @@ import { LocalAudioTrack, LocalVideoTrack, RemoteAudioTrack, RemoteVideoTrack } 
 type TrackType = LocalAudioTrack | LocalVideoTrack | RemoteAudioTrack | RemoteVideoTrack | undefined;
 
 export default function useIsTrackEnabled(track: TrackType) {
-  const [isEnabled, setIsEnabled] = useState(track ? track.isEnabled : true);
+  const [isEnabled, setIsEnabled] = useState(track ? track.isEnabled : false);
 
   useEffect(() => {
-    setIsEnabled(track ? track.isEnabled : true);
+    setIsEnabled(track ? track.isEnabled : false);
 
     if (track) {
       const setEnabled = () => setIsEnabled(true);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

Fix a bug where the Mute Button shows that the audio is enabled when no track is present.

With this change, we will see the MicOff icon when no local audio track is present.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary