### PR TITLE
Hide ToggleFullscreenButton when not supported

### DIFF
--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, FormEvent, useState, useEffect } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import fscreen from 'fscreen';
 
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
@@ -136,7 +137,7 @@ export default function MenuBar() {
         <div className={classes.rightButtonContainer}>
           <FlipCameraButton />
           <DeviceSelector />
-          <ToggleFullscreenButton />
+          {fscreen.fullscreenEnabled && <ToggleFullscreenButton />}
           <Menu />
         </div>
       </Toolbar>


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

When using the application on iPhone, the ToggleFullscreenButton does not work. It's because iOS Safari on iPhone doesn't support the Full Screen API:
https://caniuse.com/#feat=fullscreen

I think it could be better to display the ToggleFullscreenButton only if the Full Screen API is supported by the browser. What do you think?

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary