### PR TITLE
Firefox media permission fix

### DIFF
--- a/src/__mocks__/twilio-video.ts
+++ b/src/__mocks__/twilio-video.ts
@@ -10,10 +10,18 @@ class MockRoom extends EventEmitter {
 
 const mockRoom = new MockRoom();
 
+class MockTrack extends EventEmitter {
+  kind = '';
+
+  constructor(kind: string) {
+    super();
+    this.kind = kind;
+  }
+}
+
 const twilioVideo = {
   connect: jest.fn(() => Promise.resolve(mockRoom)),
-  createLocalAudioTrack: jest.fn(() => Promise.resolve(new EventEmitter())),
-  createLocalVideoTrack: jest.fn(() => Promise.resolve(new EventEmitter())),
+  createLocalTracks: jest.fn(() => Promise.resolve([new MockTrack('video'), new MockTrack('audio')])),
 };
 
 export { mockRoom };

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.test.tsx
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.test.tsx
@@ -8,6 +8,8 @@ import { EventEmitter } from 'events';
 navigator.mediaDevices = { enumerateDevices: () => Promise.resolve([{ deviceId: 1, label: '1' }]) };
 
 describe('the useLocalTracks hook', () => {
+  afterEach(jest.clearAllMocks);
+
   it('should return an array of tracks and two functions', async () => {
     const { result, waitForNextUpdate } = renderHook(useLocalTracks);
     expect(result.current.localTracks).toEqual([]);
@@ -16,16 +18,18 @@ describe('the useLocalTracks hook', () => {
     expect(result.current.getLocalVideoTrack).toEqual(expect.any(Function));
   });
 
-  it('should be called with the correct arguments', async () => {
+  it('should create local tracks when loaded', async () => {
     Date.now = () => 123456;
     const { waitForNextUpdate } = renderHook(useLocalTracks);
     await waitForNextUpdate();
-    expect(Video.createLocalAudioTrack).toHaveBeenCalled();
-    expect(Video.createLocalVideoTrack).toHaveBeenCalledWith({
-      frameRate: 24,
-      height: 720,
-      width: 1280,
-      name: 'camera-123456',
+    expect(Video.createLocalTracks).toHaveBeenCalledWith({
+      audio: true,
+      video: {
+        frameRate: 24,
+        width: 1280,
+        height: 720,
+        name: 'camera-123456',
+      },
     });
   });
 

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -1,6 +1,4 @@
 import { useCallback, useEffect, useState } from 'react';
-
-import { ensureMediaPermissions } from '../../../utils';
 import Video, { LocalVideoTrack, LocalAudioTrack, CreateLocalTrackOptions } from 'twilio-video';
 
 export default function useLocalTracks() {
@@ -15,12 +13,10 @@ export default function useLocalTracks() {
       options.deviceId = { exact: deviceId };
     }
 
-    return ensureMediaPermissions().then(() =>
-      Video.createLocalAudioTrack(options).then(newTrack => {
-        setAudioTrack(newTrack);
-        return newTrack;
-      })
-    );
+    return Video.createLocalAudioTrack(options).then(newTrack => {
+      setAudioTrack(newTrack);
+      return newTrack;
+    });
   }, []);
 
   const getLocalVideoTrack = useCallback((newOptions?: CreateLocalTrackOptions) => {
@@ -37,12 +33,10 @@ export default function useLocalTracks() {
       ...newOptions,
     };
 
-    return ensureMediaPermissions().then(() =>
-      Video.createLocalVideoTrack(options).then(newTrack => {
-        setVideoTrack(newTrack);
-        return newTrack;
-      })
-    );
+    return Video.createLocalVideoTrack(options).then(newTrack => {
+      setVideoTrack(newTrack);
+      return newTrack;
+    });
   }, []);
 
   useEffect(() => {

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -51,7 +51,6 @@ export default function useLocalTracks() {
       audio: true,
     })
       .then(tracks => {
-        console.log(tracks);
         const videoTrack = tracks.find(track => track.kind === 'video');
         const audioTrack = tracks.find(track => track.kind === 'audio');
         if (videoTrack) {

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -3,9 +3,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { ensureMediaPermissions } from '../../../utils';
 import Video, { LocalVideoTrack, LocalAudioTrack, CreateLocalTrackOptions } from 'twilio-video';
 
-export function useLocalAudioTrack() {
-  const [track, setTrack] = useState<LocalAudioTrack>();
-  const [isAcquiringLocalAudioTrack, setIsAcquiringLocalAudioTrack] = useState(false);
+export default function useLocalTracks() {
+  const [audioTrack, setAudioTrack] = useState<LocalAudioTrack>();
+  const [videoTrack, setVideoTrack] = useState<LocalVideoTrack>();
+  const [isAcquiringLocalTracks, setIsAcquiringLocalTracks] = useState(false);
 
   const getLocalAudioTrack = useCallback((deviceId?: string) => {
     const options: CreateLocalTrackOptions = {};
@@ -16,34 +17,11 @@ export function useLocalAudioTrack() {
 
     return ensureMediaPermissions().then(() =>
       Video.createLocalAudioTrack(options).then(newTrack => {
-        setTrack(newTrack);
+        setAudioTrack(newTrack);
         return newTrack;
       })
     );
   }, []);
-
-  useEffect(() => {
-    // We get a new local audio track when the app loads.
-    setIsAcquiringLocalAudioTrack(true);
-    getLocalAudioTrack().finally(() => setIsAcquiringLocalAudioTrack(false));
-  }, [getLocalAudioTrack]);
-
-  useEffect(() => {
-    const handleStopped = () => setTrack(undefined);
-    if (track) {
-      track.on('stopped', handleStopped);
-      return () => {
-        track.off('stopped', handleStopped);
-      };
-    }
-  }, [track]);
-
-  return { audioTrack: track, getLocalAudioTrack, isAcquiringLocalAudioTrack };
-}
-
-export function useLocalVideoTrack() {
-  const [track, setTrack] = useState<LocalVideoTrack>();
-  const [isAcquiringLocalVideoTrack, setIsAcquiringLocalVideoTrack] = useState(false);
 
   const getLocalVideoTrack = useCallback((newOptions?: CreateLocalTrackOptions) => {
     // In the DeviceSelector and FlipCameraButton components, a new video track is created,
@@ -61,36 +39,56 @@ export function useLocalVideoTrack() {
 
     return ensureMediaPermissions().then(() =>
       Video.createLocalVideoTrack(options).then(newTrack => {
-        setTrack(newTrack);
+        setVideoTrack(newTrack);
         return newTrack;
       })
     );
   }, []);
 
   useEffect(() => {
-    // We get a new local video track when the app loads.
-    setIsAcquiringLocalVideoTrack(true);
-    getLocalVideoTrack().finally(() => setIsAcquiringLocalVideoTrack(false));
-  }, [getLocalVideoTrack]);
+    setIsAcquiringLocalTracks(true);
+    Video.createLocalTracks({
+      video: {
+        frameRate: 24,
+        height: 720,
+        width: 1280,
+        name: `camera-${Date.now()}`,
+      },
+      audio: true,
+    })
+      .then(tracks => {
+        console.log(tracks);
+        const videoTrack = tracks.find(track => track.kind === 'video');
+        const audioTrack = tracks.find(track => track.kind === 'audio');
+        if (videoTrack) {
+          setVideoTrack(videoTrack as LocalVideoTrack);
+        }
+        if (audioTrack) {
+          setAudioTrack(audioTrack as LocalAudioTrack);
+        }
+      })
+      .finally(() => setIsAcquiringLocalTracks(false));
+  }, []);
 
   useEffect(() => {
-    const handleStopped = () => setTrack(undefined);
-    if (track) {
-      track.on('stopped', handleStopped);
+    const handleStopped = () => setAudioTrack(undefined);
+    if (audioTrack) {
+      audioTrack.on('stopped', handleStopped);
       return () => {
-        track.off('stopped', handleStopped);
+        audioTrack.off('stopped', handleStopped);
       };
     }
-  }, [track]);
+  }, [audioTrack]);
 
-  return { videoTrack: track, getLocalVideoTrack, isAcquiringLocalVideoTrack };
-}
-
-export default function useLocalTracks() {
-  const { audioTrack, getLocalAudioTrack, isAcquiringLocalAudioTrack } = useLocalAudioTrack();
-  const { videoTrack, getLocalVideoTrack, isAcquiringLocalVideoTrack } = useLocalVideoTrack();
-
-  const isAcquiringLocalTracks = isAcquiringLocalAudioTrack || isAcquiringLocalVideoTrack;
+  useEffect(() => {
+    const handleStopped = () => setVideoTrack(undefined);
+    if (videoTrack) {
+      videoTrack.on('stopped', handleStopped);
+      return () => {
+        videoTrack.off('stopped', handleStopped);
+      };
+    }
+  }, [videoTrack]);
 
   const localTracks = [audioTrack, videoTrack].filter(track => track !== undefined) as (
     | LocalAudioTrack


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-682](https://issues.corp.twilio.com/browse/AHOYAPPS-682)

### Description

This PR changes how permissions are requested. Now Firefox will request permissions only once. 

`ensureMediaPermissions` is no longer called before local tracks are created. `ensureMediaPermissions` is only used before `enumerateDevices` is called.

The `useLocalTracks` hook has been rewritten so that local audio and video are no longer requested separately. Now they are requested at the same time with `Video.createLocalTracks({audio: true, video: { ... }})`. 

This means that `getUserMedia` is called only once on application start. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary