### PR TITLE
Fix video publishing

### DIFF
--- a/src/components/Controls/ToggleVideoButton/ToggleVideoButton.test.tsx
+++ b/src/components/Controls/ToggleVideoButton/ToggleVideoButton.test.tsx
@@ -32,4 +32,18 @@ describe('the ToggleVideoButton component', () => {
     wrapper.find('WithStyles(ForwardRef(Fab))').simulate('click');
     expect(mockFn).toHaveBeenCalled();
   });
+
+  it('should throttle the toggle function to 200ms', () => {
+    const mockFn = jest.fn();
+    mockUseLocalVideoToggle.mockImplementation(() => [false, mockFn]);
+    const wrapper = shallow(<ToggleVideoButton />);
+    const button = wrapper.find('WithStyles(ForwardRef(Fab))');
+    Date.now = () => 100000;
+    button.simulate('click'); // Should register
+    Date.now = () => 100100;
+    button.simulate('click'); // Should be ignored
+    Date.now = () => 100300;
+    button.simulate('click'); // Should register
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/components/Controls/ToggleVideoButton/ToggleVideoButton.tsx
+++ b/src/components/Controls/ToggleVideoButton/ToggleVideoButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 import Fab from '@material-ui/core/Fab';
@@ -19,6 +19,14 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function ToggleVideoButton(props: { disabled?: boolean }) {
   const classes = useStyles();
   const [isVideoEnabled, toggleVideoEnabled] = useLocalVideoToggle();
+  const lastClickTimeRef = useRef(0);
+
+  const toggleVideo = useCallback(() => {
+    if (Date.now() - lastClickTimeRef.current > 200) {
+      lastClickTimeRef.current = Date.now();
+      toggleVideoEnabled();
+    }
+  }, [toggleVideoEnabled]);
 
   return (
     <Tooltip
@@ -26,7 +34,7 @@ export default function ToggleVideoButton(props: { disabled?: boolean }) {
       placement="top"
       PopperProps={{ disablePortal: true }}
     >
-      <Fab className={classes.fab} onClick={toggleVideoEnabled} disabled={props.disabled}>
+      <Fab className={classes.fab} onClick={toggleVideo} disabled={props.disabled}>
         {isVideoEnabled ? <Videocam /> : <VideocamOff />}
       </Fab>
     </Tooltip>

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
@@ -131,5 +131,27 @@ describe('the useLocalVideoToggle hook', () => {
       expect(mockGetLocalVideoTrack).toHaveBeenCalledTimes(1);
       await waitForNextUpdate();
     });
+
+    it('should not call onError when LocalParticipant throws an error', async () => {
+      const mockGetLocalVideoTrack = jest.fn(() => Promise.resolve('mocmockTrack'));
+      const mockOnError = jest.fn();
+
+      const mockLocalParticipant = new EventEmitter() as LocalParticipant;
+      mockLocalParticipant.publishTrack = jest.fn(() => Promise.reject('mockError'));
+
+      mockUseVideoContext.mockImplementation(() => ({
+        localTracks: [],
+        getLocalVideoTrack: mockGetLocalVideoTrack,
+        room: { localParticipant: mockLocalParticipant },
+        onError: mockOnError,
+      }));
+
+      const { result, waitForNextUpdate } = renderHook(useLocalVideoToggle);
+      act(() => {
+        result.current[1]();
+      });
+      await waitForNextUpdate();
+      expect(mockOnError).toHaveBeenCalledWith('mockError');
+    });
   });
 });

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import useLocalVideoToggle from './useLocalVideoToggle';
 import useVideoContext from '../useVideoContext/useVideoContext';
 import { EventEmitter } from 'events';
@@ -72,7 +72,7 @@ describe('the useLocalVideoToggle hook', () => {
       expect(mockLocalParticipant.unpublishTrack).toHaveBeenCalledWith(mockLocalTrack);
     });
 
-    it('should call getLocalVideoTrack when a localVideoTrack does not exist', () => {
+    it('should call getLocalVideoTrack when a localVideoTrack does not exist', async () => {
       const mockGetLocalVideoTrack = jest.fn(() => Promise.resolve());
       mockUseVideoContext.mockImplementation(() => ({
         localTracks: [],
@@ -80,12 +80,15 @@ describe('the useLocalVideoToggle hook', () => {
         room: {},
       }));
 
-      const { result } = renderHook(useLocalVideoToggle);
-      result.current[1]();
+      const { result, waitForNextUpdate } = renderHook(useLocalVideoToggle);
+      act(() => {
+        result.current[1]();
+      });
+      await waitForNextUpdate();
       expect(mockGetLocalVideoTrack).toHaveBeenCalled();
     });
 
-    it('should call mockLocalParticipant.publishTrack when a localVideoTrack does not exist and localParticipant does exist', done => {
+    it('should call mockLocalParticipant.publishTrack when a localVideoTrack does not exist and localParticipant does exist', async done => {
       const mockGetLocalVideoTrack = jest.fn(() => Promise.resolve('mockTrack'));
 
       const mockLocalParticipant = new EventEmitter() as LocalParticipant;
@@ -97,12 +100,36 @@ describe('the useLocalVideoToggle hook', () => {
         room: { localParticipant: mockLocalParticipant },
       }));
 
-      const { result } = renderHook(useLocalVideoToggle);
-      result.current[1]();
+      const { result, waitForNextUpdate } = renderHook(useLocalVideoToggle);
+      act(() => {
+        result.current[1]();
+      });
+      await waitForNextUpdate();
       setImmediate(() => {
         expect(mockLocalParticipant.publishTrack).toHaveBeenCalledWith('mockTrack', { priority: 'low' });
         done();
       });
+    });
+
+    it('should not call mockLocalParticipant.publishTrack when isPublishing is true', async () => {
+      const mockGetLocalVideoTrack = jest.fn(() => Promise.resolve('mockTrack'));
+
+      const mockLocalParticipant = new EventEmitter() as LocalParticipant;
+      mockLocalParticipant.publishTrack = jest.fn();
+
+      mockUseVideoContext.mockImplementation(() => ({
+        localTracks: [],
+        getLocalVideoTrack: mockGetLocalVideoTrack,
+        room: { localParticipant: mockLocalParticipant },
+      }));
+
+      const { result, waitForNextUpdate } = renderHook(useLocalVideoToggle);
+      act(() => {
+        result.current[1]();
+      });
+      result.current[1](); // Should be ignored because isPublishing is true
+      expect(mockGetLocalVideoTrack).toHaveBeenCalledTimes(1);
+      await waitForNextUpdate();
     });
   });
 });

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
@@ -1,5 +1,5 @@
 import { LocalVideoTrack } from 'twilio-video';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import useVideoContext from '../useVideoContext/useVideoContext';
 
 export default function useLocalVideoToggle() {
@@ -9,23 +9,23 @@ export default function useLocalVideoToggle() {
     getLocalVideoTrack,
   } = useVideoContext();
   const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack;
+  const [isPublishing, setIspublishing] = useState(false);
 
   const toggleVideoEnabled = useCallback(() => {
-    if (videoTrack) {
-      if (localParticipant) {
-        const localTrackPublication = localParticipant.unpublishTrack(videoTrack);
+    if (!isPublishing) {
+      if (videoTrack) {
+        const localTrackPublication = localParticipant?.unpublishTrack(videoTrack);
         // TODO: remove when SDK implements this event. See: https://issues.corp.twilio.com/browse/JSDK-2592
-        localParticipant.emit('trackUnpublished', localTrackPublication);
+        localParticipant?.emit('trackUnpublished', localTrackPublication);
+        videoTrack.stop();
+      } else {
+        setIspublishing(true);
+        getLocalVideoTrack()
+          .then((track: LocalVideoTrack) => localParticipant?.publishTrack(track, { priority: 'low' }))
+          .then(() => setIspublishing(false));
       }
-      videoTrack.stop();
-    } else {
-      getLocalVideoTrack().then((track: LocalVideoTrack) => {
-        if (localParticipant) {
-          localParticipant.publishTrack(track, { priority: 'low' });
-        }
-      });
     }
-  }, [videoTrack, localParticipant, getLocalVideoTrack]);
+  }, [videoTrack, localParticipant, getLocalVideoTrack, isPublishing]);
 
   return [!!videoTrack, toggleVideoEnabled] as const;
 }

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
@@ -7,6 +7,7 @@ export default function useLocalVideoToggle() {
     room: { localParticipant },
     localTracks,
     getLocalVideoTrack,
+    onError,
   } = useVideoContext();
   const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack;
   const [isPublishing, setIspublishing] = useState(false);
@@ -22,7 +23,8 @@ export default function useLocalVideoToggle() {
         setIspublishing(true);
         getLocalVideoTrack()
           .then((track: LocalVideoTrack) => localParticipant?.publishTrack(track, { priority: 'low' }))
-          .then(() => setIspublishing(false));
+          .catch(onError)
+          .finally(() => setIspublishing(false));
       }
     }
   }, [videoTrack, localParticipant, getLocalVideoTrack, isPublishing]);

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
@@ -27,7 +27,7 @@ export default function useLocalVideoToggle() {
           .finally(() => setIspublishing(false));
       }
     }
-  }, [videoTrack, localParticipant, getLocalVideoTrack, isPublishing]);
+  }, [videoTrack, localParticipant, getLocalVideoTrack, isPublishing, onError]);
 
   return [!!videoTrack, toggleVideoEnabled] as const;
 }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-683](https://issues.corp.twilio.com/browse/AHOYAPPS-683)

### Description

This PR changes the logic of the publishing/unpublishing of the local video track in the following ways:

- The Mute Video button is now throttled so that it can only be clicked once every 200ms. This prevents issues caused by clicking the button excessively fast.
- The useLocalVideoToggle hook only publishes/unpublishes the local video track when it is not already doing so.
- If there is a publishing error, an error modal will be displayed instead of the app crashing. 

Resolves #218 and #233 

This PR can be manually tested by entering a room, and then clicking the Mute Video button as quickly as possible. There will be no errors and the button will work as expected. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary