### PR TITLE
Ahoyapps 515 unsupported browsers

### DIFF
--- a/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.test.tsx
+++ b/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import UnsupportedBrowserWarning from './UnsupportedBrowserWarning';
+import Video from 'twilio-video';
+import { shallow } from 'enzyme';
+
+describe('the UnsupportedBrowserWarning component', () => {
+  it('should render correctly when isSupported is false and isSecureContext is true', () => {
+    // @ts-ignore
+    Video.isSupported = false;
+    // @ts-ignore
+    window.isSecureContext = true;
+    const wrapper = shallow(
+      <UnsupportedBrowserWarning>
+        <span>Is supported</span>
+      </UnsupportedBrowserWarning>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render correctly when isSupported is false and isSecureContext is true', () => {
+    // @ts-ignore
+    Video.isSupported = false;
+    // @ts-ignore
+    window.isSecureContext = false;
+    const wrapper = shallow(
+      <UnsupportedBrowserWarning>
+        <span>Is supported</span>
+      </UnsupportedBrowserWarning>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render children when browser is supported', () => {
+    // @ts-ignore
+    Video.isSupported = true;
+    // @ts-ignore
+    window.isSecureContext = true;
+    const wrapper = shallow(
+      <UnsupportedBrowserWarning>
+        <span>Is supported</span>
+      </UnsupportedBrowserWarning>
+    );
+    expect(wrapper.text()).toBe('Is supported');
+  });
+});

--- a/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.test.tsx
+++ b/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.test.tsx
@@ -4,11 +4,9 @@ import Video from 'twilio-video';
 import { shallow } from 'enzyme';
 
 describe('the UnsupportedBrowserWarning component', () => {
-  it('should render correctly when isSupported is false and isSecureContext is true', () => {
+  it('should render correctly when isSupported is false', () => {
     // @ts-ignore
     Video.isSupported = false;
-    // @ts-ignore
-    window.isSecureContext = true;
     const wrapper = shallow(
       <UnsupportedBrowserWarning>
         <span>Is supported</span>
@@ -17,24 +15,9 @@ describe('the UnsupportedBrowserWarning component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render correctly when isSupported is false and isSecureContext is true', () => {
-    // @ts-ignore
-    Video.isSupported = false;
-    // @ts-ignore
-    window.isSecureContext = false;
-    const wrapper = shallow(
-      <UnsupportedBrowserWarning>
-        <span>Is supported</span>
-      </UnsupportedBrowserWarning>
-    );
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should render children when browser is supported', () => {
+  it('should render children when isSupported is true', () => {
     // @ts-ignore
     Video.isSupported = true;
-    // @ts-ignore
-    window.isSecureContext = true;
     const wrapper = shallow(
       <UnsupportedBrowserWarning>
         <span>Is supported</span>

--- a/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.tsx
+++ b/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import Video from 'twilio-video';
+import { Container, Link, Typography, Paper, Grid } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  container: {
+    marginTop: '2.5em',
+  },
+  paper: {
+    padding: '1em',
+  },
+  heading: {
+    marginBottom: '0.4em',
+  },
+});
+
+export default function({ children }: { children: React.ReactElement }) {
+  const classes = useStyles();
+
+  if (!Video.isSupported) {
+    return (
+      <Container>
+        <Grid container justify="center" className={classes.container}>
+          <Grid item xs={12} sm={6}>
+            <Paper className={classes.paper}>
+              <Typography variant="h4" className={classes.heading}>
+                Browser not supported
+              </Typography>
+              <Typography>
+                This is not a supported browser. Please refer to our list of{' '}
+                <Link
+                  href="https://www.twilio.com/docs/video/javascript#supported-browsers"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  supported browsers
+                </Link>
+                .
+                <br />
+                {!window.isSecureContext && (
+                  <>
+                    If you are using a browser on the supported browser list, please ensure that this app is served over
+                    a secure context. This app must be served over a secure context (e.g. https or localhost). Please
+                    see:{' '}
+                    <Link
+                      href="https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts"
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+                    </Link>
+                    .
+                  </>
+                )}
+              </Typography>
+            </Paper>
+          </Grid>
+        </Grid>
+      </Container>
+    );
+  }
+
+  return children;
+}

--- a/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.tsx
+++ b/src/components/UnsupportedBrowserWarning/UnsupportedBrowserWarning.tsx
@@ -25,10 +25,10 @@ export default function({ children }: { children: React.ReactElement }) {
           <Grid item xs={12} sm={6}>
             <Paper className={classes.paper}>
               <Typography variant="h4" className={classes.heading}>
-                Browser not supported
+                Browser or context not supported
               </Typography>
               <Typography>
-                This is not a supported browser. Please refer to our list of{' '}
+                Please open this application in one of the{' '}
                 <Link
                   href="https://www.twilio.com/docs/video/javascript#supported-browsers"
                   target="_blank"
@@ -38,21 +38,15 @@ export default function({ children }: { children: React.ReactElement }) {
                 </Link>
                 .
                 <br />
-                {!window.isSecureContext && (
-                  <>
-                    If you are using a browser on the supported browser list, please ensure that this app is served over
-                    a secure context. This app must be served over a secure context (e.g. https or localhost). Please
-                    see:{' '}
-                    <Link
-                      href="https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts"
-                      target="_blank"
-                      rel="noopener"
-                    >
-                      https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
-                    </Link>
-                    .
-                  </>
-                )}
+                If you are using a supported browser, please ensure that this app is served over a{' '}
+                <Link
+                  href="https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  secure context
+                </Link>{' '}
+                (e.g. https or localhost).
               </Typography>
             </Paper>
           </Grid>

--- a/src/components/UnsupportedBrowserWarning/__snapshots__/UnsupportedBrowserWarning.test.tsx.snap
+++ b/src/components/UnsupportedBrowserWarning/__snapshots__/UnsupportedBrowserWarning.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the UnsupportedBrowserWarning component should render correctly when isSupported is false and isSecureContext is true 1`] = `
+exports[`the UnsupportedBrowserWarning component should render correctly when isSupported is false 1`] = `
 <WithStyles(ForwardRef(Container))>
   <WithStyles(ForwardRef(Grid))
     className="makeStyles-container-1"
@@ -19,10 +19,10 @@ exports[`the UnsupportedBrowserWarning component should render correctly when is
           className="makeStyles-heading-3"
           variant="h4"
         >
-          Browser not supported
+          Browser or context not supported
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          This is not a supported browser. Please refer to our list of
+          Please open this application in one of the
            
           <WithStyles(ForwardRef(Link))
             href="https://www.twilio.com/docs/video/javascript#supported-browsers"
@@ -33,56 +33,17 @@ exports[`the UnsupportedBrowserWarning component should render correctly when is
           </WithStyles(ForwardRef(Link))>
           .
           <br />
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Paper))>
-    </WithStyles(ForwardRef(Grid))>
-  </WithStyles(ForwardRef(Grid))>
-</WithStyles(ForwardRef(Container))>
-`;
-
-exports[`the UnsupportedBrowserWarning component should render correctly when isSupported is false and isSecureContext is true 2`] = `
-<WithStyles(ForwardRef(Container))>
-  <WithStyles(ForwardRef(Grid))
-    className="makeStyles-container-1"
-    container={true}
-    justify="center"
-  >
-    <WithStyles(ForwardRef(Grid))
-      item={true}
-      sm={6}
-      xs={12}
-    >
-      <WithStyles(ForwardRef(Paper))
-        className="makeStyles-paper-2"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="makeStyles-heading-3"
-          variant="h4"
-        >
-          Browser not supported
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))>
-          This is not a supported browser. Please refer to our list of
-           
-          <WithStyles(ForwardRef(Link))
-            href="https://www.twilio.com/docs/video/javascript#supported-browsers"
-            rel="noopener"
-            target="_blank"
-          >
-            supported browsers
-          </WithStyles(ForwardRef(Link))>
-          .
-          <br />
-          If you are using a browser on the supported browser list, please ensure that this app is served over a secure context. This app must be served over a secure context (e.g. https or localhost). Please see:
+          If you are using a supported browser, please ensure that this app is served over a
            
           <WithStyles(ForwardRef(Link))
             href="https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts"
             rel="noopener"
             target="_blank"
           >
-            https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+            secure context
           </WithStyles(ForwardRef(Link))>
-          .
+           
+          (e.g. https or localhost).
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Paper))>
     </WithStyles(ForwardRef(Grid))>

--- a/src/components/UnsupportedBrowserWarning/__snapshots__/UnsupportedBrowserWarning.test.tsx.snap
+++ b/src/components/UnsupportedBrowserWarning/__snapshots__/UnsupportedBrowserWarning.test.tsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the UnsupportedBrowserWarning component should render correctly when isSupported is false and isSecureContext is true 1`] = `
+<WithStyles(ForwardRef(Container))>
+  <WithStyles(ForwardRef(Grid))
+    className="makeStyles-container-1"
+    container={true}
+    justify="center"
+  >
+    <WithStyles(ForwardRef(Grid))
+      item={true}
+      sm={6}
+      xs={12}
+    >
+      <WithStyles(ForwardRef(Paper))
+        className="makeStyles-paper-2"
+      >
+        <WithStyles(ForwardRef(Typography))
+          className="makeStyles-heading-3"
+          variant="h4"
+        >
+          Browser not supported
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          This is not a supported browser. Please refer to our list of
+           
+          <WithStyles(ForwardRef(Link))
+            href="https://www.twilio.com/docs/video/javascript#supported-browsers"
+            rel="noopener"
+            target="_blank"
+          >
+            supported browsers
+          </WithStyles(ForwardRef(Link))>
+          .
+          <br />
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Paper))>
+    </WithStyles(ForwardRef(Grid))>
+  </WithStyles(ForwardRef(Grid))>
+</WithStyles(ForwardRef(Container))>
+`;
+
+exports[`the UnsupportedBrowserWarning component should render correctly when isSupported is false and isSecureContext is true 2`] = `
+<WithStyles(ForwardRef(Container))>
+  <WithStyles(ForwardRef(Grid))
+    className="makeStyles-container-1"
+    container={true}
+    justify="center"
+  >
+    <WithStyles(ForwardRef(Grid))
+      item={true}
+      sm={6}
+      xs={12}
+    >
+      <WithStyles(ForwardRef(Paper))
+        className="makeStyles-paper-2"
+      >
+        <WithStyles(ForwardRef(Typography))
+          className="makeStyles-heading-3"
+          variant="h4"
+        >
+          Browser not supported
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          This is not a supported browser. Please refer to our list of
+           
+          <WithStyles(ForwardRef(Link))
+            href="https://www.twilio.com/docs/video/javascript#supported-browsers"
+            rel="noopener"
+            target="_blank"
+          >
+            supported browsers
+          </WithStyles(ForwardRef(Link))>
+          .
+          <br />
+          If you are using a browser on the supported browser list, please ensure that this app is served over a secure context. This app must be served over a secure context (e.g. https or localhost). Please see:
+           
+          <WithStyles(ForwardRef(Link))
+            href="https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts"
+            rel="noopener"
+            target="_blank"
+          >
+            https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+          </WithStyles(ForwardRef(Link))>
+          .
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Paper))>
+    </WithStyles(ForwardRef(Grid))>
+  </WithStyles(ForwardRef(Grid))>
+</WithStyles(ForwardRef(Container))>
+`;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,19 +14,19 @@ import PrivateRoute from './components/PrivateRoute/PrivateRoute';
 import theme from './theme';
 import './types';
 import { VideoProvider } from './components/VideoProvider';
-import UnsupportedBrowserWarnings from './components/UnsupportedBrowserWarning/UnsupportedBrowserWarning';
+import UnsupportedBrowserWarning from './components/UnsupportedBrowserWarning/UnsupportedBrowserWarning';
 
 const VideoApp = () => {
   const { error, setError, settings } = useAppState();
   const connectionOptions = generateConnectionOptions(settings);
 
   return (
-    <VideoProvider options={connectionOptions} onError={setError}>
-      <ErrorDialog dismissError={() => setError(null)} error={error} />
-      <UnsupportedBrowserWarnings>
+    <UnsupportedBrowserWarning>
+      <VideoProvider options={connectionOptions} onError={setError}>
+        <ErrorDialog dismissError={() => setError(null)} error={error} />
         <App />
-      </UnsupportedBrowserWarnings>
-    </VideoProvider>
+      </VideoProvider>
+    </UnsupportedBrowserWarning>
   );
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import PrivateRoute from './components/PrivateRoute/PrivateRoute';
 import theme from './theme';
 import './types';
 import { VideoProvider } from './components/VideoProvider';
+import UnsupportedBrowserWarnings from './components/UnsupportedBrowserWarning/UnsupportedBrowserWarning';
 
 const VideoApp = () => {
   const { error, setError, settings } = useAppState();
@@ -22,7 +23,9 @@ const VideoApp = () => {
   return (
     <VideoProvider options={connectionOptions} onError={setError}>
       <ErrorDialog dismissError={() => setError(null)} error={error} />
-      <App />
+      <UnsupportedBrowserWarnings>
+        <App />
+      </UnsupportedBrowserWarnings>
     </VideoProvider>
   );
 };


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-515](https://issues.corp.twilio.com/browse/AHOYAPPS-515)

### Description

This PR adds a useful error message if the `isSupported` boolean is `true`. 

`isSupported` is always false when `window.isSecureContext` is false. In such cases we display the following text:

![image](https://user-images.githubusercontent.com/12685223/84548655-58678180-acc3-11ea-9606-b60826b70092.png)

In cases where the browser is not supported, but the context is secure, the following error is displayed:

![image](https://user-images.githubusercontent.com/12685223/84548691-7af99a80-acc3-11ea-9b55-104c7ad83d22.png)

The link takes the user to our documentation: https://www.twilio.com/docs/video/javascript#supported-browsers

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary