### PR TITLE
Set max tracks based on browser

### DIFF
--- a/src/components/MenuBar/ConnectionOptions/__snapshots__/ConnectionOptions.test.tsx.snap
+++ b/src/components/MenuBar/ConnectionOptions/__snapshots__/ConnectionOptions.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`the ConnectionOptions component when connected to a room should render 
           name="maxTracks"
           onChange={[Function]}
           placeholder="Leave blank for no limit"
-          value="0"
+          value="10"
         />
       </WithStyles(ForwardRef(FormControl))>
       <WithStyles(ForwardRef(FormControl))
@@ -572,7 +572,7 @@ exports[`the ConnectionOptions component when not connected to a room should ren
           name="maxTracks"
           onChange={[Function]}
           placeholder="Leave blank for no limit"
-          value="0"
+          value="10"
         />
       </WithStyles(ForwardRef(FormControl))>
       <WithStyles(ForwardRef(FormControl))

--- a/src/state/settings/settingsReducer.test.ts
+++ b/src/state/settings/settingsReducer.test.ts
@@ -8,7 +8,7 @@ describe('the settingsReducer', () => {
       bandwidthProfileMode: 'collaboration',
       dominantSpeakerPriority: 'standard',
       maxAudioBitrate: '16000',
-      maxTracks: '0',
+      maxTracks: '10',
       renderDimensionHigh: 'test',
       renderDimensionLow: 'low',
       renderDimensionStandard: '960p',
@@ -22,12 +22,25 @@ describe('the settingsReducer', () => {
       bandwidthProfileMode: undefined,
       dominantSpeakerPriority: 'standard',
       maxAudioBitrate: '16000',
-      maxTracks: '0',
+      maxTracks: '10',
       renderDimensionHigh: 'wide1080p',
       renderDimensionLow: 'low',
       renderDimensionStandard: '960p',
       trackSwitchOffMode: undefined,
     });
+  });
+
+  it('should set the maxTracks property to 10 when not using a mobile browser', () => {
+    jest.resetModules();
+    const { initialSettings } = require('./settingsReducer');
+    expect(initialSettings.maxTracks).toBe('10');
+  });
+
+  it('should set the maxTracks property to 5 when using a mobile browser', () => {
+    Object.defineProperty(navigator, 'userAgent', { value: 'Mobile' });
+    jest.resetModules();
+    const { initialSettings } = jest.requireActual('./settingsReducer');
+    expect(initialSettings.maxTracks).toBe('5');
   });
 });
 

--- a/src/state/settings/settingsReducer.ts
+++ b/src/state/settings/settingsReducer.ts
@@ -1,5 +1,6 @@
-import { Track, VideoBandwidthProfileOptions } from 'twilio-video';
+import { isMobile } from '../../utils';
 import { RenderDimensionValue } from './renderDimensions';
+import { Track, VideoBandwidthProfileOptions } from 'twilio-video';
 
 export interface Settings {
   trackSwitchOffMode: VideoBandwidthProfileOptions['trackSwitchOffMode'];
@@ -23,7 +24,7 @@ export const initialSettings: Settings = {
   trackSwitchOffMode: undefined,
   dominantSpeakerPriority: 'standard',
   bandwidthProfileMode: 'collaboration',
-  maxTracks: '0',
+  maxTracks: isMobile ? '5' : '10',
   maxAudioBitrate: '16000',
   renderDimensionLow: 'low',
   renderDimensionStandard: '960p',


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-596](https://issues.corp.twilio.com/browse/AHOYAPPS-596)

### Description

This PR changes the default setting for max tracks to 10 for desktop browsers and 5 for mobile browsers. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary