### PR TITLE
Prepare app for twilio-video 2.6.0 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2238,9 +2238,9 @@
       }
     },
     "@twilio/webrtc": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@twilio/webrtc/-/webrtc-4.2.1.tgz",
-      "integrity": "sha512-JoJ+q3Zf0jWbn2yFjLu+C068+lw4A12507UnxTbQTGBg0mcCqC3msjl5dkJgXMc6hS48nICAGEPvTrEOUB7YBA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@twilio/webrtc/-/webrtc-4.3.0.tgz",
+      "integrity": "sha512-a0ieFb0XUc5HQIMGBypwvTFVxyBEpPvTgnz2E08KxyZvM72igYlAFjZyooq/5BDctu3cJmT9H3coNaUX82l8yw=="
     },
     "@types/babel__core": {
       "version": "7.1.6",
@@ -2594,9 +2594,9 @@
       }
     },
     "@types/twilio-video": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/twilio-video/-/twilio-video-2.0.10.tgz",
-      "integrity": "sha512-85ojlHUSXarLXsF7hZZ1fANXI0Jjuctq998egegOT9BaTG7jy3yUK9GK/a40LudzvslKAholkSHrNn2a+HD2KA=="
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@types/twilio-video/-/twilio-video-2.0.12.tgz",
+      "integrity": "sha512-GrkdzvOFxGFOGlThKcjQce32Pwycoubl5oQK5+H4KSeyDvGHzyZSbnX7qoyWFMXKSHBc165f3dw+oORdr2E7ew=="
     },
     "@types/yargs": {
       "version": "13.0.3",
@@ -2924,12 +2924,6 @@
           }
         }
       }
-    },
-    "adm-zip": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
-      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g==",
-      "optional": true
     },
     "agent-base": {
       "version": "5.1.1",
@@ -4432,18 +4426,6 @@
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "requires": {
         "tslib": "^1.9.0"
-      }
-    },
-    "chromedriver": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.28.0.tgz",
-      "integrity": "sha1-6gw4NiHdJ9s0DGErhf45QUwW7Hk=",
-      "optional": true,
-      "requires": {
-        "adm-zip": "^0.4.7",
-        "kew": "^0.7.0",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4"
       }
     },
     "ci-info": {
@@ -6113,21 +6095,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "optional": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "optional": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -7002,6 +6969,7 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
       "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
       "requires": {
         "concat-stream": "1.6.2",
         "debug": "2.6.9",
@@ -7013,6 +6981,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -7020,12 +6989,14 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "yauzl": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+          "dev": true,
           "requires": {
             "fd-slicer": "~1.0.1"
           }
@@ -7092,6 +7063,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -11348,12 +11320,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "optional": true
-    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -13729,7 +13695,8 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -14973,7 +14940,8 @@
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -18515,75 +18483,16 @@
       }
     },
     "twilio-video": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.5.0.tgz",
-      "integrity": "sha512-mc2JnZkwYHmedOhPyW6ypcbA1ieMey1g2IFAFGi+X9o8mmfWIm1iFgHW6M32O8BrjrE571C7UOpUQobKMmuUrQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.6.0.tgz",
+      "integrity": "sha512-Q/IR7UUc5PTU1uDEzZQuSaeaQH3OOTyw5Xklmq6oqomymVqYDZ6CEuEMHsqxtDajoIOSaflalWYDIQoSE+hS3Q==",
       "requires": {
-        "@twilio/webrtc": "4.2.1",
+        "@twilio/webrtc": "4.3.0",
         "backoff": "^2.5.0",
-        "chromedriver": "2.28.0",
-        "puppeteer": "^1.11.0",
         "ws": "^3.3.1",
         "xmlhttprequest": "^1.8.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "optional": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-          "optional": true,
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "optional": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
-          }
-        },
-        "puppeteer": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
-          "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "extract-zip": "^1.6.6",
-            "https-proxy-agent": "^2.2.1",
-            "mime": "^2.0.3",
-            "progress": "^2.0.1",
-            "proxy-from-env": "^1.0.0",
-            "rimraf": "^2.6.1",
-            "ws": "^6.1.0"
-          },
-          "dependencies": {
-            "ws": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-              "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-              "optional": true,
-              "requires": {
-                "async-limiter": "~1.0.0"
-              }
-            }
-          }
-        },
         "ws": {
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-scripts": "^3.4.1",
     "strip-color": "^0.1.0",
     "twilio": "^3.39.3",
-    "twilio-video": "^2.5.0",
+    "twilio-video": "^2.6.0",
     "typescript": "^3.8.3"
   },
   "devDependencies": {

--- a/src/__mocks__/twilio-video.ts
+++ b/src/__mocks__/twilio-video.ts
@@ -12,6 +12,7 @@ const mockRoom = new MockRoom();
 
 class MockTrack extends EventEmitter {
   kind = '';
+  stop = jest.fn();
 
   constructor(kind: string) {
     super();

--- a/src/components/VideoProvider/index.tsx
+++ b/src/components/VideoProvider/index.tsx
@@ -34,6 +34,7 @@ export interface IVideoContext {
   getLocalVideoTrack: (newOptions?: CreateLocalTrackOptions) => Promise<LocalVideoTrack>;
   getLocalAudioTrack: (deviceId?: string) => Promise<LocalAudioTrack>;
   isAcquiringLocalTracks: boolean;
+  removeLocalVideoTrack: () => void;
 }
 
 export const VideoContext = createContext<IVideoContext>(null!);
@@ -51,7 +52,13 @@ export function VideoProvider({ options, children, onError = () => {}, onDisconn
     onError(error);
   };
 
-  const { localTracks, getLocalVideoTrack, getLocalAudioTrack, isAcquiringLocalTracks } = useLocalTracks();
+  const {
+    localTracks,
+    getLocalVideoTrack,
+    getLocalAudioTrack,
+    isAcquiringLocalTracks,
+    removeLocalVideoTrack,
+  } = useLocalTracks();
   const { room, isConnecting, connect } = useRoom(localTracks, onErrorCallback, options);
 
   // Register onError and onDisconnect callback functions.
@@ -71,6 +78,7 @@ export function VideoProvider({ options, children, onError = () => {}, onDisconn
         getLocalAudioTrack,
         connect,
         isAcquiringLocalTracks,
+        removeLocalVideoTrack,
       }}
     >
       <SelectedParticipantProvider room={room}>{children}</SelectedParticipantProvider>

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -39,6 +39,13 @@ export default function useLocalTracks() {
     });
   }, []);
 
+  const removeLocalVideoTrack = useCallback(() => {
+    if (videoTrack) {
+      videoTrack.stop();
+      setVideoTrack(undefined);
+    }
+  }, [videoTrack]);
+
   useEffect(() => {
     setIsAcquiringLocalTracks(true);
     Video.createLocalTracks({
@@ -63,30 +70,10 @@ export default function useLocalTracks() {
       .finally(() => setIsAcquiringLocalTracks(false));
   }, []);
 
-  useEffect(() => {
-    const handleStopped = () => setAudioTrack(undefined);
-    if (audioTrack) {
-      audioTrack.on('stopped', handleStopped);
-      return () => {
-        audioTrack.off('stopped', handleStopped);
-      };
-    }
-  }, [audioTrack]);
-
-  useEffect(() => {
-    const handleStopped = () => setVideoTrack(undefined);
-    if (videoTrack) {
-      videoTrack.on('stopped', handleStopped);
-      return () => {
-        videoTrack.off('stopped', handleStopped);
-      };
-    }
-  }, [videoTrack]);
-
   const localTracks = [audioTrack, videoTrack].filter(track => track !== undefined) as (
     | LocalAudioTrack
     | LocalVideoTrack
   )[];
 
-  return { localTracks, getLocalVideoTrack, getLocalAudioTrack, isAcquiringLocalTracks };
+  return { localTracks, getLocalVideoTrack, getLocalAudioTrack, isAcquiringLocalTracks, removeLocalVideoTrack };
 }

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
@@ -36,21 +36,19 @@ describe('the useLocalVideoToggle hook', () => {
     expect(result.current).toEqual([false, expect.any(Function)]);
   });
 
-  describe('toggleAudioEnabled function', () => {
-    it('should call track.stop when a localVideoTrack exists', () => {
-      const mockLocalTrack = {
-        name: 'camera-123456',
-        stop: jest.fn(),
-      };
+  describe('toggleVideoEnabled function', () => {
+    it('should call removeLocalVideoTrack when a localVideoTrack exists', () => {
+      const mockRemoveLocalVideoTrack = jest.fn();
 
       mockUseVideoContext.mockImplementation(() => ({
-        localTracks: [mockLocalTrack],
+        localTracks: [{ name: 'camera' }],
         room: { localParticipant: null },
+        removeLocalVideoTrack: mockRemoveLocalVideoTrack,
       }));
 
       const { result } = renderHook(useLocalVideoToggle);
       result.current[1]();
-      expect(mockLocalTrack.stop).toHaveBeenCalled();
+      expect(mockRemoveLocalVideoTrack).toHaveBeenCalled();
     });
 
     it('should call localParticipant.unpublishTrack when a localVideoTrack and localParticipant exists', () => {
@@ -65,6 +63,7 @@ describe('the useLocalVideoToggle hook', () => {
       mockUseVideoContext.mockImplementation(() => ({
         localTracks: [mockLocalTrack],
         room: { localParticipant: mockLocalParticipant },
+        removeLocalVideoTrack: () => {},
       }));
 
       const { result } = renderHook(useLocalVideoToggle);
@@ -132,8 +131,8 @@ describe('the useLocalVideoToggle hook', () => {
       await waitForNextUpdate();
     });
 
-    it('should not call onError when LocalParticipant throws an error', async () => {
-      const mockGetLocalVideoTrack = jest.fn(() => Promise.resolve('mocmockTrack'));
+    it('should call onError when publishTrack throws an error', async () => {
+      const mockGetLocalVideoTrack = jest.fn(() => Promise.resolve('mockTrack'));
       const mockOnError = jest.fn();
 
       const mockLocalParticipant = new EventEmitter() as LocalParticipant;

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
@@ -7,6 +7,7 @@ export default function useLocalVideoToggle() {
     room: { localParticipant },
     localTracks,
     getLocalVideoTrack,
+    removeLocalVideoTrack,
     onError,
   } = useVideoContext();
   const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack;
@@ -18,7 +19,7 @@ export default function useLocalVideoToggle() {
         const localTrackPublication = localParticipant?.unpublishTrack(videoTrack);
         // TODO: remove when SDK implements this event. See: https://issues.corp.twilio.com/browse/JSDK-2592
         localParticipant?.emit('trackUnpublished', localTrackPublication);
-        videoTrack.stop();
+        removeLocalVideoTrack();
       } else {
         setIspublishing(true);
         getLocalVideoTrack()
@@ -27,7 +28,7 @@ export default function useLocalVideoToggle() {
           .finally(() => setIspublishing(false));
       }
     }
-  }, [videoTrack, localParticipant, getLocalVideoTrack, isPublishing, onError]);
+  }, [videoTrack, localParticipant, getLocalVideoTrack, isPublishing, onError, removeLocalVideoTrack]);
 
   return [!!videoTrack, toggleVideoEnabled] as const;
 }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR updates the version of Twilio-video to 2.6.0. 

The Twilio-video SDK version 2.6.0 contains a fix for a known iOS Safari audio issue (see the [Changelog](https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md#260-june-26-2020)). This workaround requires that small parts of the React application be changed. Since it's possible that local tracks may be restarted by the SDK after a stopped event is fired, the React app must not remove local tracks from state when a stopped event is fired. Thus we remove the listeners in `useLocalTracks.tsx` (see [here](https://github.com/twilio/twilio-video-app-react/compare/2-6-0-prep#diff-e4ef94c367863a8e81fe334623b780ffL66)).

Additionally, we _do_ need to remove the local video track from state after a user clicks on the 'Mute Video' button, so we create a `removeLocalVideoTrack` function in `useLocalTracks.tsx` (see [here](https://github.com/twilio/twilio-video-app-react/compare/2-6-0-prep#diff-e4ef94c367863a8e81fe334623b780ffR42)). This `removeLocalVideoTrack` function can be accessed with the `useVideoContext` hook. See it's usage in `useLocalVideoToggle.tsx` [here](https://github.com/twilio/twilio-video-app-react/compare/2-6-0-prep#diff-d36652af41663154cc9ebf8835c34c2aR22).

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary