### PR TITLE
Ahoyapps 734 add track restart feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18483,9 +18483,8 @@
       }
     },
     "twilio-video": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.6.0.tgz",
-      "integrity": "sha512-Q/IR7UUc5PTU1uDEzZQuSaeaQH3OOTyw5Xklmq6oqomymVqYDZ6CEuEMHsqxtDajoIOSaflalWYDIQoSE+hS3Q==",
+      "version": "https://github.com/twilio/twilio-video.js/archive/2.7.0-rc2.tar.gz",
+      "integrity": "sha512-K3LlFCBDMairAkw/zrrvSm3XqNoou+6fVaGiWnVTsGgEauKJvOOq8k6BmSTbJAqyJEd3ol1Hll37B6fZfLx1WA==",
       "requires": {
         "@twilio/webrtc": "4.3.0",
         "backoff": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2238,9 +2238,9 @@
       }
     },
     "@twilio/webrtc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@twilio/webrtc/-/webrtc-4.3.0.tgz",
-      "integrity": "sha512-a0ieFb0XUc5HQIMGBypwvTFVxyBEpPvTgnz2E08KxyZvM72igYlAFjZyooq/5BDctu3cJmT9H3coNaUX82l8yw=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@twilio/webrtc/-/webrtc-4.3.1.tgz",
+      "integrity": "sha512-T9Slk8TyKrKqjc4PH4aPknjmEozny/M1TzVyfRRyEQSt548hXXhLYrSp3nUcK49bfzVrgbYuRj6ojExYh2qLqw=="
     },
     "@types/babel__core": {
       "version": "7.1.6",
@@ -18483,10 +18483,11 @@
       }
     },
     "twilio-video": {
-      "version": "https://github.com/twilio/twilio-video.js/archive/2.7.0-rc2.tar.gz",
-      "integrity": "sha512-K3LlFCBDMairAkw/zrrvSm3XqNoou+6fVaGiWnVTsGgEauKJvOOq8k6BmSTbJAqyJEd3ol1Hll37B6fZfLx1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.7.0.tgz",
+      "integrity": "sha512-juAMupRjBGh1pqVvE9CwpMGoGyJOlmJbzG2C3TstK1bAcHDLFUvFkBlNwL+ubIUTipX0nrrxzVfcQrEI3wWHqA==",
       "requires": {
-        "@twilio/webrtc": "4.3.0",
+        "@twilio/webrtc": "4.3.1",
         "backoff": "^2.5.0",
         "ws": "^3.3.1",
         "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-scripts": "^3.4.1",
     "strip-color": "^0.1.0",
     "twilio": "^3.39.3",
-    "twilio-video": "https://github.com/twilio/twilio-video.js/archive/2.7.0-rc2.tar.gz",
+    "twilio-video": "^2.7.0",
     "typescript": "^3.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-scripts": "^3.4.1",
     "strip-color": "^0.1.0",
     "twilio": "^3.39.3",
-    "twilio-video": "^2.6.0",
+    "twilio-video": "https://github.com/twilio/twilio-video.js/archive/2.7.0-rc2.tar.gz",
     "typescript": "^3.8.3"
   },
   "devDependencies": {

--- a/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
+++ b/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AudioTrack, LocalAudioTrack, RemoteAudioTrack } from 'twilio-video';
 import { interval } from 'd3-timer';
 import MicOff from '@material-ui/icons/MicOff';
 import useIsTrackEnabled from '../../hooks/useIsTrackEnabled/useIsTrackEnabled';
+import useMediaStreamTrack from '../../hooks/useMediaStreamTrack/useMediaStreamTrack';
 
 let clipId = 0;
 const getUniqueClipId = () => clipId++;
@@ -33,42 +34,50 @@ function AudioLevelIndicator({
   background?: string;
 }) {
   const SIZE = size || 24;
-  const ref = useRef<SVGRectElement>(null);
-  const mediaStreamRef = useRef<MediaStream>();
+  const SVGRectRef = useRef<SVGRectElement>(null);
+  const [analyser, setAnalyser] = useState<AnalyserNode>();
   const isTrackEnabled = useIsTrackEnabled(audioTrack as LocalAudioTrack | RemoteAudioTrack);
+  const mediaStreamTrack = useMediaStreamTrack(audioTrack);
 
   useEffect(() => {
-    // Here we listen for the 'stopped' event on the audioTrack. When the audioTrack is stopped,
-    // we stop the cloned track that is stored in mediaStreamRef. It is important that we stop
-    // all tracks when they are not in use. Browsers like Firefox don't let you create a stream
-    // from a new audio device while the active audio device still has active tracks.
-    const handleStopped = () => mediaStreamRef.current?.getTracks().forEach(track => track.stop());
-    audioTrack?.on('stopped', handleStopped);
-    return () => {
-      audioTrack?.off('stopped', handleStopped);
-    };
-  }, [audioTrack]);
-
-  useEffect(() => {
-    const SVGClipElement = ref.current;
-
-    if (audioTrack && isTrackEnabled && SVGClipElement) {
+    if (mediaStreamTrack) {
       // Here we create a new MediaStream from a clone of the mediaStreamTrack.
       // A clone is created to allow multiple instances of this component for a single
       // AudioTrack on iOS Safari. It is stored in a ref so that the cloned track can be stopped
       // when the original track is stopped.
-      mediaStreamRef.current = new MediaStream([audioTrack.mediaStreamTrack.clone()]);
-      let analyser = initializeAnalyser(mediaStreamRef.current);
+      let newMediaStream = new MediaStream([mediaStreamTrack.clone()]);
+
+      // Here we listen for the 'stopped' event on the audioTrack. When the audioTrack is stopped,
+      // we stop the cloned track that is stored in mediaStreamRef. It is important that we stop
+      // all tracks when they are not in use. Browsers like Firefox don't let you create a stream
+      // from a new audio device while the active audio device still has active tracks.
+      const handleStopped = () => newMediaStream.getTracks().forEach(track => track.stop());
 
       const reinitializeAnalyser = () => {
-        analyser = initializeAnalyser(mediaStreamRef.current!);
+        handleStopped();
+        newMediaStream = new MediaStream([mediaStreamTrack.clone()]);
+        setAnalyser(initializeAnalyser(newMediaStream));
       };
+
+      setAnalyser(initializeAnalyser(newMediaStream));
 
       // Here we reinitialize the AnalyserNode on focus to avoid an issue in Safari
       // where the analysers stop functioning when the user switches to a new tab
       // and switches back to the app.
       window.addEventListener('focus', reinitializeAnalyser);
+      audioTrack!.on('stopped', handleStopped);
 
+      return () => {
+        window.removeEventListener('focus', reinitializeAnalyser);
+        audioTrack!.off('stopped', handleStopped);
+      };
+    }
+  }, [mediaStreamTrack, audioTrack]);
+
+  useEffect(() => {
+    const SVGClipElement = SVGRectRef.current;
+
+    if (isTrackEnabled && SVGClipElement && analyser) {
       const sampleArray = new Uint8Array(analyser.frequencyBinCount);
 
       const timer = interval(() => {
@@ -88,10 +97,9 @@ function AudioLevelIndicator({
       return () => {
         SVGClipElement.setAttribute('y', '21');
         timer.stop();
-        window.removeEventListener('focus', reinitializeAnalyser);
       };
     }
-  }, [audioTrack, isTrackEnabled]);
+  }, [isTrackEnabled, analyser]);
 
   // Each instance of this component will need a unique HTML ID
   const clipPathId = `audio-level-clip-${getUniqueClipId()}`;
@@ -100,7 +108,7 @@ function AudioLevelIndicator({
     <svg focusable="false" viewBox="0 0 24 24" aria-hidden="true" height={`${SIZE}px`} width={`${SIZE}px`}>
       <defs>
         <clipPath id={clipPathId}>
-          <rect ref={ref} x="0" y="21" width="24" height="24" />
+          <rect ref={SVGRectRef} x="0" y="21" width="24" height="24" />
         </clipPath>
       </defs>
       <path

--- a/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
+++ b/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
@@ -40,7 +40,7 @@ function AudioLevelIndicator({
   const mediaStreamTrack = useMediaStreamTrack(audioTrack);
 
   useEffect(() => {
-    if (mediaStreamTrack) {
+    if (audioTrack && mediaStreamTrack) {
       // Here we create a new MediaStream from a clone of the mediaStreamTrack.
       // A clone is created to allow multiple instances of this component for a single
       // AudioTrack on iOS Safari.
@@ -51,7 +51,7 @@ function AudioLevelIndicator({
       // all tracks when they are not in use. Browsers like Firefox don't let you create a new stream
       // from a new audio device while the active audio device still has active tracks.
       const stopAllMediaStreamTracks = () => newMediaStream.getTracks().forEach(track => track.stop());
-      audioTrack!.on('stopped', stopAllMediaStreamTracks);
+      audioTrack.on('stopped', stopAllMediaStreamTracks);
 
       const reinitializeAnalyser = () => {
         stopAllMediaStreamTracks();
@@ -68,7 +68,7 @@ function AudioLevelIndicator({
 
       return () => {
         window.removeEventListener('focus', reinitializeAnalyser);
-        audioTrack!.off('stopped', stopAllMediaStreamTracks);
+        audioTrack.off('stopped', stopAllMediaStreamTracks);
       };
     }
   }, [mediaStreamTrack, audioTrack]);

--- a/src/components/LocalVideoPreview/LocalVideoPreview.test.tsx
+++ b/src/components/LocalVideoPreview/LocalVideoPreview.test.tsx
@@ -5,6 +5,7 @@ import { IVideoContext } from '../VideoProvider';
 import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
 
 jest.mock('../../hooks/useVideoContext/useVideoContext');
+jest.mock('../../hooks/useMediaStreamTrack/useMediaStreamTrack');
 
 const mockedVideoContext = useVideoContext as jest.Mock<IVideoContext>;
 

--- a/src/components/MenuBar/DeviceSelector/AudioInputList/AudioInputList.tsx
+++ b/src/components/MenuBar/DeviceSelector/AudioInputList/AudioInputList.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { FormControl, MenuItem, Typography, Select } from '@material-ui/core';
 import LocalAudioLevelIndicator from '../LocalAudioLevelIndicator/LocalAudioLevelIndicator';
 import { makeStyles } from '@material-ui/core/styles';
 import { useAudioInputDevices } from '../deviceHooks/deviceHooks';
+import useMediaStreamTrack from '../../../../hooks/useMediaStreamTrack/useMediaStreamTrack';
 import useVideoContext from '../../../../hooks/useVideoContext/useVideoContext';
 
 const useStyles = makeStyles({
@@ -19,17 +20,8 @@ export default function AudioInputList() {
   const { localTracks } = useVideoContext();
 
   const localAudioTrack = localTracks.find(track => track.kind === 'audio');
-  const [localAudioInputDeviceId, setLocalAudioInputDeviceId] = useState(
-    localAudioTrack?.mediaStreamTrack.getSettings().deviceId
-  );
-
-  useEffect(() => {
-    const handleStarted = () => setLocalAudioInputDeviceId(localAudioTrack?.mediaStreamTrack.getSettings().deviceId);
-    localAudioTrack?.on('started', handleStarted);
-    return () => {
-      localAudioTrack?.on('started', handleStarted);
-    };
-  }, [localAudioTrack]);
+  const mediaStreamTrack = useMediaStreamTrack(localAudioTrack);
+  const localAudioInputDeviceId = mediaStreamTrack?.getSettings().deviceId;
 
   function replaceTrack(newDeviceId: string) {
     localAudioTrack?.restart({ deviceId: { exact: newDeviceId } });

--- a/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
+++ b/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
@@ -16,26 +16,15 @@ const useStyles = makeStyles({
 export default function VideoInputList() {
   const classes = useStyles();
   const videoInputDevices = useVideoInputDevices();
-  const {
-    room: { localParticipant },
-    localTracks,
-    getLocalVideoTrack,
-  } = useVideoContext();
+  const { localTracks } = useVideoContext();
 
   const localVideoTrack = localTracks.find(track => track.kind === 'video') as LocalVideoTrack;
   const localVideoInputDeviceId = localVideoTrack?.mediaStreamTrack.getSettings().deviceId;
 
   function replaceTrack(newDeviceId: string) {
-    localVideoTrack?.stop();
-    getLocalVideoTrack({ deviceId: { exact: newDeviceId } }).then(newTrack => {
-      if (localVideoTrack) {
-        const localTrackPublication = localParticipant?.unpublishTrack(localVideoTrack);
-        // TODO: remove when SDK implements this event. See: https://issues.corp.twilio.com/browse/JSDK-2592
-        localParticipant?.emit('trackUnpublished', localTrackPublication);
-      }
-
-      localParticipant?.publishTrack(newTrack);
-    });
+    const constraints = localVideoTrack.mediaStreamTrack.getSettings();
+    delete constraints.facingMode;
+    localVideoTrack.restart({ ...constraints, deviceId: { exact: newDeviceId } });
   }
 
   return (

--- a/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
+++ b/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { FormControl, MenuItem, Typography, Select } from '@material-ui/core';
 import { LocalVideoTrack } from 'twilio-video';
 import { makeStyles } from '@material-ui/core/styles';
+import VideoTrack from '../../../VideoTrack/VideoTrack';
+import { VIDEO_TRACK_WIDTH, VIDEO_TRACK_HEIGHT, VIDEO_TRACK_FRAMERATE } from '../../../../constants';
+import useMediaStreamTrack from '../../../../hooks/useMediaStreamTrack/useMediaStreamTrack';
 import useVideoContext from '../../../../hooks/useVideoContext/useVideoContext';
 import { useVideoInputDevices } from '../deviceHooks/deviceHooks';
-import VideoTrack from '../../../VideoTrack/VideoTrack';
 
 const useStyles = makeStyles({
   preview: {
@@ -19,22 +21,16 @@ export default function VideoInputList() {
   const { localTracks } = useVideoContext();
 
   const localVideoTrack = localTracks.find(track => track.kind === 'video') as LocalVideoTrack;
-  const [localVideoInputDeviceId, setLocalVideoInputDeviceId] = useState(
-    localVideoTrack?.mediaStreamTrack.getSettings().deviceId
-  );
-
-  useEffect(() => {
-    const handleStarted = () => setLocalVideoInputDeviceId(localVideoTrack?.mediaStreamTrack.getSettings().deviceId);
-    localVideoTrack?.on('started', handleStarted);
-    return () => {
-      localVideoTrack?.on('started', handleStarted);
-    };
-  }, [localVideoTrack]);
+  const mediaStreamTrack = useMediaStreamTrack(localVideoTrack);
+  const localVideoInputDeviceId = mediaStreamTrack?.getSettings().deviceId;
 
   function replaceTrack(newDeviceId: string) {
-    const constraints = localVideoTrack.mediaStreamTrack.getConstraints();
-    delete constraints.facingMode;
-    localVideoTrack.restart({ ...constraints, deviceId: { exact: newDeviceId } });
+    localVideoTrack.restart({
+      width: VIDEO_TRACK_WIDTH,
+      height: VIDEO_TRACK_HEIGHT,
+      frameRate: VIDEO_TRACK_FRAMERATE,
+      deviceId: { exact: newDeviceId },
+    });
   }
 
   return (

--- a/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
+++ b/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { DEFAULT_VIDEO_CONSTRAINTS } from '../../../../constants';
 import { FormControl, MenuItem, Typography, Select } from '@material-ui/core';
 import { LocalVideoTrack } from 'twilio-video';
 import { makeStyles } from '@material-ui/core/styles';
 import VideoTrack from '../../../VideoTrack/VideoTrack';
-import { VIDEO_TRACK_WIDTH, VIDEO_TRACK_HEIGHT, VIDEO_TRACK_FRAMERATE } from '../../../../constants';
 import useMediaStreamTrack from '../../../../hooks/useMediaStreamTrack/useMediaStreamTrack';
 import useVideoContext from '../../../../hooks/useVideoContext/useVideoContext';
 import { useVideoInputDevices } from '../deviceHooks/deviceHooks';
@@ -26,9 +26,7 @@ export default function VideoInputList() {
 
   function replaceTrack(newDeviceId: string) {
     localVideoTrack.restart({
-      width: VIDEO_TRACK_WIDTH,
-      height: VIDEO_TRACK_HEIGHT,
-      frameRate: VIDEO_TRACK_FRAMERATE,
+      ...(DEFAULT_VIDEO_CONSTRAINTS as {}),
       deviceId: { exact: newDeviceId },
     });
   }

--- a/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
+++ b/src/components/MenuBar/DeviceSelector/VideoInputList/VideoInputList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { FormControl, MenuItem, Typography, Select } from '@material-ui/core';
 import { LocalVideoTrack } from 'twilio-video';
 import { makeStyles } from '@material-ui/core/styles';
@@ -19,10 +19,20 @@ export default function VideoInputList() {
   const { localTracks } = useVideoContext();
 
   const localVideoTrack = localTracks.find(track => track.kind === 'video') as LocalVideoTrack;
-  const localVideoInputDeviceId = localVideoTrack?.mediaStreamTrack.getSettings().deviceId;
+  const [localVideoInputDeviceId, setLocalVideoInputDeviceId] = useState(
+    localVideoTrack?.mediaStreamTrack.getSettings().deviceId
+  );
+
+  useEffect(() => {
+    const handleStarted = () => setLocalVideoInputDeviceId(localVideoTrack?.mediaStreamTrack.getSettings().deviceId);
+    localVideoTrack?.on('started', handleStarted);
+    return () => {
+      localVideoTrack?.on('started', handleStarted);
+    };
+  }, [localVideoTrack]);
 
   function replaceTrack(newDeviceId: string) {
-    const constraints = localVideoTrack.mediaStreamTrack.getSettings();
+    const constraints = localVideoTrack.mediaStreamTrack.getConstraints();
     delete constraints.facingMode;
     localVideoTrack.restart({ ...constraints, deviceId: { exact: newDeviceId } });
   }

--- a/src/components/MenuBar/FlipCameraButton/FlipCameraButton.test.tsx
+++ b/src/components/MenuBar/FlipCameraButton/FlipCameraButton.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act, render, fireEvent } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import FlipCameraButton from './FlipCameraButton';
 import useVideoContext from '../../../hooks/useVideoContext/useVideoContext';
-import { VIDEO_TRACK_WIDTH, VIDEO_TRACK_HEIGHT, VIDEO_TRACK_FRAMERATE } from '../../../constants';
+import { DEFAULT_VIDEO_CONSTRAINTS } from '../../../constants';
 
 jest.mock('../../../hooks/useMediaStreamTrack/useMediaStreamTrack');
 jest.mock('../../../hooks/useVideoContext/useVideoContext');
@@ -72,10 +72,8 @@ describe('the FlipCameraButton', () => {
     const { container } = render(<FlipCameraButton />);
     fireEvent.click(container.querySelector('button')!);
     expect(mockVideoTrack.restart).toHaveBeenCalledWith({
+      ...(DEFAULT_VIDEO_CONSTRAINTS as {}),
       facingMode: 'user',
-      width: VIDEO_TRACK_WIDTH,
-      height: VIDEO_TRACK_HEIGHT,
-      frameRate: VIDEO_TRACK_FRAMERATE,
     });
   });
 });

--- a/src/components/MenuBar/FlipCameraButton/FlipCameraButton.test.tsx
+++ b/src/components/MenuBar/FlipCameraButton/FlipCameraButton.test.tsx
@@ -8,12 +8,6 @@ jest.mock('../../../hooks/useMediaStreamTrack/useMediaStreamTrack');
 jest.mock('../../../hooks/useVideoContext/useVideoContext');
 const mockUserVideoContext = useVideoContext as jest.Mock<any>;
 
-const mockLocalParticipant = {
-  emit: jest.fn(),
-  publishTrack: jest.fn(),
-  unpublishTrack: jest.fn(() => 'mockPublication'),
-};
-
 const mockStreamSettings = { facingMode: 'user' };
 
 const mockVideoTrack = {
@@ -21,14 +15,10 @@ const mockVideoTrack = {
   mediaStreamTrack: {
     getSettings: () => mockStreamSettings,
   },
-  stop: jest.fn(),
   restart: jest.fn(),
 };
 
 const mockVideoContext = {
-  room: {
-    localParticipant: mockLocalParticipant,
-  },
   localTracks: [mockVideoTrack],
   getLocalVideoTrack: jest.fn(() => Promise.resolve('newMockTrack')),
 };
@@ -67,7 +57,7 @@ describe('the FlipCameraButton', () => {
     expect(container.querySelector('button')).not.toBeTruthy();
   });
 
-  it('should request the front facing video track when the current track is rear facing when clicked', async () => {
+  it('should call track.replace() with the correct facing mode when clicked', async () => {
     mockUserVideoContext.mockImplementation(() => ({
       ...mockVideoContext,
       localTracks: [

--- a/src/components/MenuBar/FlipCameraButton/FlipCameraButton.tsx
+++ b/src/components/MenuBar/FlipCameraButton/FlipCameraButton.tsx
@@ -28,10 +28,11 @@ export default function FlipCameraButton() {
   }, [videoTrack, supportsFacingMode]);
 
   const toggleFacingMode = useCallback(() => {
-    const constraints = videoTrack.mediaStreamTrack.getSettings();
+    const currentFacingMode = videoTrack.mediaStreamTrack.getSettings().facingMode;
+    const constraints = videoTrack.mediaStreamTrack.getConstraints();
     delete constraints.deviceId;
-    const newFacingMode = constraints.facingMode === 'user' ? 'environment' : 'user';
-    console.log(newFacingMode, constraints);
+    const newFacingMode = currentFacingMode === 'user' ? 'environment' : 'user';
+    console.log(constraints);
     videoTrack.restart({ ...constraints, facingMode: newFacingMode });
   }, [videoTrack]);
 

--- a/src/components/MenuBar/FlipCameraButton/FlipCameraButton.tsx
+++ b/src/components/MenuBar/FlipCameraButton/FlipCameraButton.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { DEFAULT_VIDEO_CONSTRAINTS } from '../../../constants';
 import FlipCameraIosIcon from '@material-ui/icons/FlipCameraIos';
 import { IconButton } from '@material-ui/core';
 import { LocalVideoTrack } from 'twilio-video';
 import useMediaStreamTrack from '../../../hooks/useMediaStreamTrack/useMediaStreamTrack';
 import useVideoContext from '../../../hooks/useVideoContext/useVideoContext';
-import { VIDEO_TRACK_HEIGHT, VIDEO_TRACK_FRAMERATE, VIDEO_TRACK_WIDTH } from '../../../constants';
 
 export default function FlipCameraButton() {
   const { localTracks } = useVideoContext();
@@ -27,10 +27,8 @@ export default function FlipCameraButton() {
   const toggleFacingMode = useCallback(() => {
     const newFacingMode = mediaStreamTrack?.getSettings().facingMode === 'user' ? 'environment' : 'user';
     videoTrack.restart({
+      ...(DEFAULT_VIDEO_CONSTRAINTS as {}),
       facingMode: newFacingMode,
-      width: VIDEO_TRACK_WIDTH,
-      height: VIDEO_TRACK_HEIGHT,
-      frameRate: VIDEO_TRACK_FRAMERATE,
     });
   }, [mediaStreamTrack, videoTrack]);
 

--- a/src/components/MenuBar/FlipCameraButton/FlipCameraButton.tsx
+++ b/src/components/MenuBar/FlipCameraButton/FlipCameraButton.tsx
@@ -1,40 +1,38 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import FlipCameraIosIcon from '@material-ui/icons/FlipCameraIos';
 import { IconButton } from '@material-ui/core';
-import useVideoContext from '../../../hooks/useVideoContext/useVideoContext';
 import { LocalVideoTrack } from 'twilio-video';
+import useMediaStreamTrack from '../../../hooks/useMediaStreamTrack/useMediaStreamTrack';
+import useVideoContext from '../../../hooks/useVideoContext/useVideoContext';
+import { VIDEO_TRACK_HEIGHT, VIDEO_TRACK_FRAMERATE, VIDEO_TRACK_WIDTH } from '../../../constants';
 
 export default function FlipCameraButton() {
   const { localTracks } = useVideoContext();
   const [supportsFacingMode, setSupportsFacingMode] = useState<Boolean | null>(null);
   const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack;
+  const mediaStreamTrack = useMediaStreamTrack(videoTrack);
 
   useEffect(() => {
-    const handleStarted = (track: LocalVideoTrack) => {
-      // The 'supportsFacingMode' variable determines if this component is rendered
-      // If 'facingMode' exists, we will set supportsFacingMode to true.
-      // However, if facingMode is ever undefined again (when the user unpublishes video), we
-      // won't set 'supportsFacingMode' to false. This prevents the icon from briefly
-      // disappearing when the user switches their front/rear camera.
-      const currentFacingMode = track.mediaStreamTrack.getSettings().facingMode;
-      if (currentFacingMode && supportsFacingMode === null) {
-        setSupportsFacingMode(true);
-      }
-    };
-    videoTrack?.on('started', handleStarted);
-    return () => {
-      videoTrack?.on('started', handleStarted);
-    };
-  }, [videoTrack, supportsFacingMode]);
+    // The 'supportsFacingMode' variable determines if this component is rendered
+    // If 'facingMode' exists, we will set supportsFacingMode to true.
+    // However, if facingMode is ever undefined again (when the user unpublishes video), we
+    // won't set 'supportsFacingMode' to false. This prevents the icon from briefly
+    // disappearing when the user switches their front/rear camera.
+    const currentFacingMode = mediaStreamTrack?.getSettings().facingMode;
+    if (currentFacingMode && supportsFacingMode === null) {
+      setSupportsFacingMode(true);
+    }
+  }, [mediaStreamTrack, supportsFacingMode]);
 
   const toggleFacingMode = useCallback(() => {
-    const currentFacingMode = videoTrack.mediaStreamTrack.getSettings().facingMode;
-    const constraints = videoTrack.mediaStreamTrack.getConstraints();
-    delete constraints.deviceId;
-    const newFacingMode = currentFacingMode === 'user' ? 'environment' : 'user';
-    console.log(constraints);
-    videoTrack.restart({ ...constraints, facingMode: newFacingMode });
-  }, [videoTrack]);
+    const newFacingMode = mediaStreamTrack?.getSettings().facingMode === 'user' ? 'environment' : 'user';
+    videoTrack.restart({
+      facingMode: newFacingMode,
+      width: VIDEO_TRACK_WIDTH,
+      height: VIDEO_TRACK_HEIGHT,
+      frameRate: VIDEO_TRACK_FRAMERATE,
+    });
+  }, [mediaStreamTrack, videoTrack]);
 
   return supportsFacingMode ? (
     <IconButton onClick={toggleFacingMode} disabled={!videoTrack}>

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -1,6 +1,6 @@
+import { DEFAULT_VIDEO_CONSTRAINTS } from '../../../constants';
 import { useCallback, useEffect, useState } from 'react';
 import Video, { LocalVideoTrack, LocalAudioTrack, CreateLocalTrackOptions } from 'twilio-video';
-import { VIDEO_TRACK_HEIGHT, VIDEO_TRACK_FRAMERATE, VIDEO_TRACK_WIDTH } from '../../../constants';
 
 export default function useLocalTracks() {
   const [audioTrack, setAudioTrack] = useState<LocalAudioTrack>();
@@ -27,9 +27,7 @@ export default function useLocalTracks() {
     // track name is 'camera', so here we append a timestamp to the track name to avoid the
     // conflict.
     const options: CreateLocalTrackOptions = {
-      frameRate: 24,
-      height: 720,
-      width: 1280,
+      ...(DEFAULT_VIDEO_CONSTRAINTS as {}),
       name: `camera-${Date.now()}`,
       ...newOptions,
     };
@@ -51,9 +49,7 @@ export default function useLocalTracks() {
     setIsAcquiringLocalTracks(true);
     Video.createLocalTracks({
       video: {
-        frameRate: VIDEO_TRACK_FRAMERATE,
-        height: VIDEO_TRACK_HEIGHT,
-        width: VIDEO_TRACK_WIDTH,
+        ...(DEFAULT_VIDEO_CONSTRAINTS as {}),
         name: `camera-${Date.now()}`,
       },
       audio: true,

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import Video, { LocalVideoTrack, LocalAudioTrack, CreateLocalTrackOptions } from 'twilio-video';
+import { VIDEO_TRACK_HEIGHT, VIDEO_TRACK_FRAMERATE, VIDEO_TRACK_WIDTH } from '../../../constants';
 
 export default function useLocalTracks() {
   const [audioTrack, setAudioTrack] = useState<LocalAudioTrack>();
@@ -50,9 +51,9 @@ export default function useLocalTracks() {
     setIsAcquiringLocalTracks(true);
     Video.createLocalTracks({
       video: {
-        frameRate: 24,
-        height: 720,
-        width: 1280,
+        frameRate: VIDEO_TRACK_FRAMERATE,
+        height: VIDEO_TRACK_HEIGHT,
+        width: VIDEO_TRACK_WIDTH,
         name: `camera-${Date.now()}`,
       },
       audio: true,

--- a/src/components/VideoTrack/VideoTrack.test.tsx
+++ b/src/components/VideoTrack/VideoTrack.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import VideoTrack from './VideoTrack';
 
+jest.mock('../../hooks/useMediaStreamTrack/useMediaStreamTrack');
+
 describe('the VideoTrack component', () => {
   const mockTrack = {
     attach: jest.fn(),

--- a/src/components/VideoTrack/VideoTrack.tsx
+++ b/src/components/VideoTrack/VideoTrack.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from 'react';
 import { IVideoTrack } from '../../types';
 import { styled } from '@material-ui/core/styles';
 import { Track } from 'twilio-video';
+import useMediaStreamTrack from '../../hooks/useMediaStreamTrack/useMediaStreamTrack';
 
 const Video = styled('video')({
   width: '100%',
@@ -17,6 +18,7 @@ interface VideoTrackProps {
 
 export default function VideoTrack({ track, isLocal, priority }: VideoTrackProps) {
   const ref = useRef<HTMLVideoElement>(null!);
+  const mediaStreamTrack = useMediaStreamTrack(track);
 
   useEffect(() => {
     const el = ref.current;
@@ -34,8 +36,8 @@ export default function VideoTrack({ track, isLocal, priority }: VideoTrackProps
     };
   }, [track, priority]);
 
-  // The local video track is mirrored.
-  const isFrontFacing = track.mediaStreamTrack.getSettings().facingMode !== 'environment';
+  // The local video track is mirrored if it is not facing the environment.
+  const isFrontFacing = mediaStreamTrack?.getSettings().facingMode !== 'environment';
   const style = isLocal && isFrontFacing ? { transform: 'rotateY(180deg)' } : {};
 
   return <Video ref={ref} style={style} />;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
-export const VIDEO_TRACK_HEIGHT = 780;
+export const VIDEO_TRACK_HEIGHT = 720;
 export const VIDEO_TRACK_WIDTH = 1280;
 export const VIDEO_TRACK_FRAMERATE = 24;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const VIDEO_TRACK_HEIGHT = 780;
+export const VIDEO_TRACK_WIDTH = 1280;
+export const VIDEO_TRACK_FRAMERATE = 24;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_VIDEO_CONSTRAINTS: MediaStreamConstraints['video'] = {
-  width: 720,
-  height: 1280,
+  width: 1280,
+  height: 720,
   frameRate: 24,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
-export const VIDEO_TRACK_HEIGHT = 720;
-export const VIDEO_TRACK_WIDTH = 1280;
-export const VIDEO_TRACK_FRAMERATE = 24;
+export const DEFAULT_VIDEO_CONSTRAINTS: MediaStreamConstraints['video'] = {
+  width: 720,
+  height: 1280,
+  frameRate: 24,
+};

--- a/src/hooks/useIsTrackEnabled/useIsTrackEnabled.test.tsx
+++ b/src/hooks/useIsTrackEnabled/useIsTrackEnabled.test.tsx
@@ -20,7 +20,7 @@ describe('the useIsTrackEnabled hook', () => {
     expect(result.current).toBe(false);
   });
 
-  it('should return respond to "subscribed" events', async () => {
+  it('should respond to "enabled" events', async () => {
     mockTrack.isEnabled = false;
     const { result } = renderHook(() => useIsTrackEnabled(mockTrack));
     act(() => {
@@ -29,7 +29,7 @@ describe('the useIsTrackEnabled hook', () => {
     expect(result.current).toBe(true);
   });
 
-  it('should return respond to "unsubscribed" events', async () => {
+  it('should respond to "disabled" events', async () => {
     mockTrack.isEnabled = true;
     const { result } = renderHook(() => useIsTrackEnabled(mockTrack));
     act(() => {

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
@@ -7,14 +7,21 @@ import { LocalParticipant } from 'twilio-video';
 jest.mock('../useVideoContext/useVideoContext');
 const mockUseVideoContext = useVideoContext as jest.Mock<any>;
 
+function getMockTrack(name: string, deviceId?: string) {
+  return {
+    name,
+    mediaStreamTrack: {
+      getSettings: () => ({
+        deviceId,
+      }),
+    },
+  };
+}
+
 describe('the useLocalVideoToggle hook', () => {
   it('should return true when a localVideoTrack exists', () => {
     mockUseVideoContext.mockImplementation(() => ({
-      localTracks: [
-        {
-          name: 'camera-123456',
-        },
-      ],
+      localTracks: [getMockTrack('camera-123456')],
       room: { localParticipant: {} },
     }));
 
@@ -24,11 +31,7 @@ describe('the useLocalVideoToggle hook', () => {
 
   it('should return false when a localVideoTrack does not exist', () => {
     mockUseVideoContext.mockImplementation(() => ({
-      localTracks: [
-        {
-          name: 'microphone',
-        },
-      ],
+      localTracks: [getMockTrack('microphone')],
       room: { localParticipant: {} },
     }));
 
@@ -41,7 +44,7 @@ describe('the useLocalVideoToggle hook', () => {
       const mockRemoveLocalVideoTrack = jest.fn();
 
       mockUseVideoContext.mockImplementation(() => ({
-        localTracks: [{ name: 'camera' }],
+        localTracks: [getMockTrack('camera')],
         room: { localParticipant: null },
         removeLocalVideoTrack: mockRemoveLocalVideoTrack,
       }));
@@ -53,7 +56,7 @@ describe('the useLocalVideoToggle hook', () => {
 
     it('should call localParticipant.unpublishTrack when a localVideoTrack and localParticipant exists', () => {
       const mockLocalTrack = {
-        name: 'camera-123456',
+        ...getMockTrack('camera-123456'),
         stop: jest.fn(),
       };
 
@@ -151,6 +154,38 @@ describe('the useLocalVideoToggle hook', () => {
       });
       await waitForNextUpdate();
       expect(mockOnError).toHaveBeenCalledWith('mockError');
+    });
+
+    it('should call getLocalVideoTrack with the deviceId of the previously active track', async () => {
+      const mockGetLocalVideoTrack = jest.fn(() => Promise.resolve('mockTrack'));
+
+      mockUseVideoContext.mockImplementation(() => ({
+        localTracks: [getMockTrack('camera', 'testDeviceID')],
+        room: { localParticipant: null },
+        removeLocalVideoTrack: jest.fn(),
+        getLocalVideoTrack: mockGetLocalVideoTrack,
+      }));
+
+      const { result, rerender, waitForNextUpdate } = renderHook(useLocalVideoToggle);
+
+      // Remove existing track
+      result.current[1]();
+
+      mockUseVideoContext.mockImplementation(() => ({
+        localTracks: [],
+        room: { localParticipant: null },
+        removeLocalVideoTrack: jest.fn(),
+        getLocalVideoTrack: mockGetLocalVideoTrack,
+      }));
+      rerender();
+
+      await act(async () => {
+        // Get new video track
+        result.current[1]();
+        await waitForNextUpdate();
+      });
+
+      expect(mockGetLocalVideoTrack).toHaveBeenCalledWith({ deviceId: { exact: 'testDeviceID' } });
     });
   });
 });

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
@@ -1,5 +1,5 @@
 import { LocalVideoTrack } from 'twilio-video';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import useVideoContext from '../useVideoContext/useVideoContext';
 
 export default function useLocalVideoToggle() {
@@ -12,17 +12,19 @@ export default function useLocalVideoToggle() {
   } = useVideoContext();
   const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack;
   const [isPublishing, setIspublishing] = useState(false);
+  const previousDeviceIdRef = useRef<string>();
 
   const toggleVideoEnabled = useCallback(() => {
     if (!isPublishing) {
       if (videoTrack) {
+        previousDeviceIdRef.current = videoTrack.mediaStreamTrack.getSettings().deviceId;
         const localTrackPublication = localParticipant?.unpublishTrack(videoTrack);
         // TODO: remove when SDK implements this event. See: https://issues.corp.twilio.com/browse/JSDK-2592
         localParticipant?.emit('trackUnpublished', localTrackPublication);
         removeLocalVideoTrack();
       } else {
         setIspublishing(true);
-        getLocalVideoTrack()
+        getLocalVideoTrack({ deviceId: { exact: previousDeviceIdRef.current } })
           .then((track: LocalVideoTrack) => localParticipant?.publishTrack(track, { priority: 'low' }))
           .catch(onError)
           .finally(() => setIspublishing(false));

--- a/src/hooks/useMediaStreamTrack/__mocks__/useMediaStreamTrack.ts
+++ b/src/hooks/useMediaStreamTrack/__mocks__/useMediaStreamTrack.ts
@@ -1,0 +1,1 @@
+export default (track: any) => track?.mediaStreamTrack;

--- a/src/hooks/useMediaStreamTrack/useMediaStreamTrack.test.ts
+++ b/src/hooks/useMediaStreamTrack/useMediaStreamTrack.test.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import EventEmitter from 'events';
+import useMediaStreamTrack from './useMediaStreamTrack';
+
+describe('the useMediaStreamTrack hook', () => {
+  let mockTrack: any;
+
+  beforeEach(() => {
+    mockTrack = new EventEmitter();
+    mockTrack.mediaStreamTrack = 'mockMediaStreamTrack';
+  });
+
+  it('should return undefined when track is undefined', () => {
+    const { result } = renderHook(() => useMediaStreamTrack(undefined));
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should return mockTrack.mediaStreamTrack by default', () => {
+    const { result } = renderHook(() => useMediaStreamTrack(mockTrack));
+    expect(result.current).toBe('mockMediaStreamTrack');
+  });
+
+  it('should respond to "started" events', async () => {
+    const { result } = renderHook(() => useMediaStreamTrack(mockTrack));
+    act(() => {
+      mockTrack.mediaStreamTrack = 'anotherMockMediaStreamTrack';
+      mockTrack.emit('started');
+    });
+    expect(result.current).toBe('anotherMockMediaStreamTrack');
+  });
+
+  it('should clean up listeners on unmount', () => {
+    const { unmount } = renderHook(() => useMediaStreamTrack(mockTrack));
+    unmount();
+    expect(mockTrack.listenerCount('started')).toBe(0);
+  });
+});

--- a/src/hooks/useMediaStreamTrack/useMediaStreamTrack.ts
+++ b/src/hooks/useMediaStreamTrack/useMediaStreamTrack.ts
@@ -1,9 +1,7 @@
 import { useState, useEffect } from 'react';
-import { LocalAudioTrack, LocalVideoTrack, RemoteAudioTrack, RemoteVideoTrack } from 'twilio-video';
+import { AudioTrack, VideoTrack } from 'twilio-video';
 
-type TrackType = LocalAudioTrack | LocalVideoTrack | RemoteAudioTrack | RemoteVideoTrack | undefined;
-
-export default function useMediaStreamTrack(track?: TrackType) {
+export default function useMediaStreamTrack(track?: AudioTrack | VideoTrack) {
   const [mediaStreamTrack, setMediaStreamTrack] = useState(track?.mediaStreamTrack);
 
   useEffect(() => {

--- a/src/hooks/useMediaStreamTrack/useMediaStreamTrack.ts
+++ b/src/hooks/useMediaStreamTrack/useMediaStreamTrack.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+import { LocalAudioTrack, LocalVideoTrack, RemoteAudioTrack, RemoteVideoTrack } from 'twilio-video';
+
+type TrackType = LocalAudioTrack | LocalVideoTrack | RemoteAudioTrack | RemoteVideoTrack | undefined;
+
+export default function useMediaStreamTrack(track?: TrackType) {
+  const [mediaStreamTrack, setMediaStreamTrack] = useState(track?.mediaStreamTrack);
+
+  useEffect(() => {
+    setMediaStreamTrack(track?.mediaStreamTrack);
+
+    if (track) {
+      const handleStarted = () => setMediaStreamTrack(track.mediaStreamTrack);
+
+      track.on('started', handleStarted);
+      return () => {
+        track.off('started', handleStarted);
+      };
+    }
+  }, [track]);
+
+  return mediaStreamTrack;
+}

--- a/src/hooks/useMediaStreamTrack/useMediaStreamTrack.ts
+++ b/src/hooks/useMediaStreamTrack/useMediaStreamTrack.ts
@@ -1,6 +1,13 @@
 import { useState, useEffect } from 'react';
 import { AudioTrack, VideoTrack } from 'twilio-video';
 
+/*
+ * This hook allows components to reliably use the 'mediaStreamTrack' property of
+ * an AudioTrack or a VideoTrack. Whenever 'localTrack.restart(...)' is called, it
+ * will replace the mediaStreamTrack property of the localTrack, but the localTrack
+ * object will stay the same. Therefore this hook is needed in order for components
+ * to rerender in response to the mediaStreamTrack changing.
+ */
 export default function useMediaStreamTrack(track?: AudioTrack | VideoTrack) {
   const [mediaStreamTrack, setMediaStreamTrack] = useState(track?.mediaStreamTrack);
 
@@ -9,7 +16,6 @@ export default function useMediaStreamTrack(track?: AudioTrack | VideoTrack) {
 
     if (track) {
       const handleStarted = () => setMediaStreamTrack(track.mediaStreamTrack);
-
       track.on('started', handleStarted);
       return () => {
         track.off('started', handleStarted);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,11 @@ declare module 'twilio-video' {
   interface LocalVideoTrack {
     isSwitchedOff: undefined;
     setPriority: undefined;
+    restart: (constraints: MediaStreamConstraints['video']) => Promise<void>;
+  }
+
+  interface LocalAudioTrack {
+    restart: (constraints: MediaStreamConstraints['audio']) => Promise<void>;
   }
 
   interface RemoteVideoTrack {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-734](https://issues.corp.twilio.com/browse/AHOYAPPS-734)

### Description

This PR upgrades twilio-video to 2.7.0 and implements the new `track.restart()` feature.  The `track.restart()` feature allows users to change the constraints of their local audio and video tracks without the hassle of unpublishing and republishing the tracks to/from the room.

The `track.restart()` feature replaces publish/unpublish logic in the `AudioInputList`, `VideoInputList`, and `FlipCameraButton` components. 

Additionally, the `VideoTrack` and `AudioLevelIndicator` components had to be updated because they rely on the the `mediaStreamTrack` object of the local tracks. Because the `mediaStreamTrack` can now change without its parent track changing, components must now use the new `useMediaStreamTrack` hook in order to reliabley use that object. 

I've also tested that the `AudioLevelIndicator` component continues to function properly in the following scenarios:
- Switching between tabs in desktop Safari 
- Switching between audio input devices in desktop Firefox
- Multiple instances of the `AudioLevelIndicator` in iOS Safari
- iOS Safari after the microphone has been taken over by another app (Siri)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary