### PR TITLE
Audio indicator fix

### DIFF
--- a/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
+++ b/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
@@ -40,7 +40,7 @@ function AudioLevelIndicator({
   const mediaStreamTrack = useMediaStreamTrack(audioTrack);
 
   useEffect(() => {
-    if (audioTrack && mediaStreamTrack) {
+    if (audioTrack && mediaStreamTrack && isTrackEnabled) {
       // Here we create a new MediaStream from a clone of the mediaStreamTrack.
       // A clone is created to allow multiple instances of this component for a single
       // AudioTrack on iOS Safari.
@@ -67,11 +67,12 @@ function AudioLevelIndicator({
       window.addEventListener('focus', reinitializeAnalyser);
 
       return () => {
+        stopAllMediaStreamTracks();
         window.removeEventListener('focus', reinitializeAnalyser);
         audioTrack.off('stopped', stopAllMediaStreamTracks);
       };
     }
-  }, [mediaStreamTrack, audioTrack]);
+  }, [isTrackEnabled, mediaStreamTrack, audioTrack]);
 
   useEffect(() => {
     const SVGClipElement = SVGRectRef.current;


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR fixes a small issue with the AudioLevelIndicator component. Occasionally it does not respond to changes in volume, even though the other participants in the room can hear your audio. This change fixes that, and it also fixes an issue where the indicator does not respond if the AudioLevelIndicator component is instantiated while the LocalAudioTrack is disabled. It also now stops all cloned media tracks when the user mutes their audio. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary