### PR TITLE
Unpin participant when they disconnect from room

### DIFF
--- a/src/components/VideoProvider/useSelectedParticipant/useSelectedParticipant.test.tsx
+++ b/src/components/VideoProvider/useSelectedParticipant/useSelectedParticipant.test.tsx
@@ -1,35 +1,31 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, HookResult, renderHook, RenderHookResult } from '@testing-library/react-hooks';
 import { EventEmitter } from 'events';
 import React from 'react';
-import { Room } from 'twilio-video';
+import { Participant, Room } from 'twilio-video';
 import useSelectedParticipant, { SelectedParticipantProvider } from './useSelectedParticipant';
 
 describe('the useSelectedParticipant hook', () => {
   let mockRoom: Room;
+  let result: HookResult<readonly [Participant | null, (participant: Participant) => void]>;
+
   beforeEach(() => (mockRoom = new EventEmitter() as Room));
 
-  it('should return null as the default value', () => {
-    const { result } = renderHook(useSelectedParticipant, {
+  beforeEach(() => {
+    ({ result } = renderHook(useSelectedParticipant, {
       wrapper: ({ children }) => <SelectedParticipantProvider room={mockRoom}>{children}</SelectedParticipantProvider>,
-    });
+    }));
+  });
+
+  it('should return null as the default value', () => {
     expect(result.current[0]).toBe(null);
   });
 
   it('should set a selected participant', () => {
-    const { result } = renderHook(useSelectedParticipant, {
-      wrapper: ({ children }) => <SelectedParticipantProvider room={mockRoom}>{children}</SelectedParticipantProvider>,
-    });
-
     act(() => result.current[1]('mockParticipant' as any));
-
     expect(result.current[0]).toBe('mockParticipant');
   });
 
   it('should set "null" as the selected participant when the user selects the currently selected participant', () => {
-    const { result } = renderHook(useSelectedParticipant, {
-      wrapper: ({ children }) => <SelectedParticipantProvider room={mockRoom}>{children}</SelectedParticipantProvider>,
-    });
-
     act(() => result.current[1]('mockParticipant' as any));
     act(() => result.current[1]('mockParticipant' as any));
 
@@ -37,15 +33,27 @@ describe('the useSelectedParticipant hook', () => {
   });
 
   it('should set "null" as the selected participant on room disconnect', () => {
-    const { result } = renderHook(useSelectedParticipant, {
-      wrapper: ({ children }) => <SelectedParticipantProvider room={mockRoom}>{children}</SelectedParticipantProvider>,
-    });
-
     act(() => result.current[1]('mockParticipant' as any));
     expect(result.current[0]).toBe('mockParticipant');
     act(() => {
       mockRoom.emit('disconnected');
     });
     expect(result.current[0]).toBe(null);
+  });
+
+  it('should set "null" as the selected participant when the participant disconnects from the room', () => {
+    act(() => result.current[1]('mockParticipant' as any));
+    act(() => {
+      mockRoom.emit('participantDisconnected', 'mockParticipant');
+    });
+    expect(result.current[0]).toBe(null);
+  });
+
+  it('should not set "null" as the selected participant when a non-selected participant disconnects from the room', () => {
+    act(() => result.current[1]('mockParticipant' as any));
+    act(() => {
+      mockRoom.emit('participantDisconnected', 'otherMockParticipant');
+    });
+    expect(result.current[0]).toBe('mockParticipant');
   });
 });

--- a/src/components/VideoProvider/useSelectedParticipant/useSelectedParticipant.tsx
+++ b/src/components/VideoProvider/useSelectedParticipant/useSelectedParticipant.tsx
@@ -22,9 +22,14 @@ export function SelectedParticipantProvider({ room, children }: SelectedParticip
 
   useEffect(() => {
     const onDisconnect = () => _setSelectedParticipant(null);
+    const handleParticipantDisconnected = (participant: Participant) =>
+      _setSelectedParticipant(prevParticipant => (prevParticipant === participant ? null : prevParticipant));
+
     room.on('disconnected', onDisconnect);
+    room.on('participantDisconnected', handleParticipantDisconnected);
     return () => {
       room.off('disconnected', onDisconnect);
+      room.off('participantDisconnected', handleParticipantDisconnected);
     };
   }, [room]);
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-912](https://issues.corp.twilio.com/browse/AHOYAPPS-912)

### Description

This PR updates the `useSelectedParticipant` hook so that it listens to the `participantDisconnected` event. Now, when a participant leaves the room, they will be unpinned. 

Fixes #338 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary