### PR TITLE
Fix video sizing on mobile landscape

### DIFF
--- a/src/components/ParticipantInfo/ParticipantInfo.tsx
+++ b/src/components/ParticipantInfo/ParticipantInfo.tsx
@@ -15,8 +15,6 @@ import usePublications from '../../hooks/usePublications/usePublications';
 import useTrack from '../../hooks/useTrack/useTrack';
 import useParticipantIsReconnecting from '../../hooks/useParticipantIsReconnecting/useParticipantIsReconnecting';
 
-const BORDER_SIZE = 2;
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
@@ -31,8 +29,8 @@ const useStyles = makeStyles((theme: Theme) =>
         objectFit: 'contain !important',
       },
       borderRadius: '4px',
-      border: `${BORDER_SIZE}px solid rgb(245, 248, 255)`,
-      paddingTop: `calc(${(9 / 16) * 100}% - ${BORDER_SIZE}px)`,
+      border: `${theme.participantBorderWidth}px solid rgb(245, 248, 255)`,
+      paddingTop: `calc(${(9 / 16) * 100}% - ${theme.participantBorderWidth}px)`,
       background: 'black',
       [theme.breakpoints.down('sm')]: {
         height: theme.sidebarMobileHeight,

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
         overflowY: 'initial',
         overflowX: 'auto',
         display: 'flex',
-        padding: '8px',
+        padding: `${theme.sidebarMobilePadding}px`,
       },
     },
     transparentBackground: {

--- a/src/components/Room/Room.tsx
+++ b/src/components/Room/Room.tsx
@@ -3,17 +3,23 @@ import ParticipantList from '../ParticipantList/ParticipantList';
 import { styled } from '@material-ui/core/styles';
 import MainParticipant from '../MainParticipant/MainParticipant';
 
-const Container = styled('div')(({ theme }) => ({
-  position: 'relative',
-  height: '100%',
-  display: 'grid',
-  gridTemplateColumns: `1fr ${theme.sidebarWidth}px`,
-  gridTemplateRows: '100%',
-  [theme.breakpoints.down('sm')]: {
-    gridTemplateColumns: `100%`,
-    gridTemplateRows: `1fr ${theme.sidebarMobileHeight + 16}px`,
-  },
-}));
+const Container = styled('div')(({ theme }) => {
+  const totalMobileSidebarHeight = `${theme.sidebarMobileHeight +
+    theme.sidebarMobilePadding * 2 +
+    theme.participantBorderWidth}px`;
+
+  return {
+    position: 'relative',
+    height: '100%',
+    display: 'grid',
+    gridTemplateColumns: `1fr ${theme.sidebarWidth}px`,
+    gridTemplateRows: '100%',
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: `100%`,
+      gridTemplateRows: `calc(100% - ${totalMobileSidebarHeight}) ${totalMobileSidebarHeight}`,
+    },
+  };
+});
 
 export default function Room() {
   return (

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -8,6 +8,8 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     footerHeight: number;
     mobileTopBarHeight: number;
     mobileFooterHeight: number;
+    sidebarMobilePadding: number;
+    participantBorderWidth: number;
   }
 
   // allow configuration using `createMuiTheme`
@@ -18,6 +20,8 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     footerHeight: number;
     mobileTopBarHeight: number;
     mobileFooterHeight: number;
+    sidebarMobilePadding: number;
+    participantBorderWidth: number;
   }
 }
 
@@ -114,5 +118,7 @@ export default createMuiTheme({
   mobileFooterHeight: 56,
   sidebarWidth: 355,
   sidebarMobileHeight: 90,
+  sidebarMobilePadding: 8,
+  participantBorderWidth: 2,
   mobileTopBarHeight: 52,
 });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-908](https://issues.corp.twilio.com/browse/AHOYAPPS-908)

### Description

This PR adjusts some CSS so that participant thumbnails are visible on mobile devices in landscape orientation:

 ![bug](https://user-images.githubusercontent.com/12685223/97350768-77bc1100-1856-11eb-87ec-3b230589a60f.gif)

Previously, the main video would expand vertically, pushing the thumbnails out of view. That no longer happens.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary