### PR TITLE
Fix bug where getAudioAndVideoTracks was repeatedly called

### DIFF
--- a/src/components/PreJoinScreens/PreJoinScreens.test.tsx
+++ b/src/components/PreJoinScreens/PreJoinScreens.test.tsx
@@ -143,7 +143,8 @@ describe('the PreJoinScreens component', () => {
   });
 
   it('should capture errors from getAudioAndVideoTracks and pass them to the MediaErrorSnackbar component', async () => {
-    mockUseVideoContext.mockImplementation(() => ({ getAudioAndVideoTracks: () => Promise.reject('testError') }));
+    const mockGetAudioAndVideoTracks = jest.fn(() => Promise.reject('testError'));
+    mockUseVideoContext.mockImplementation(() => ({ getAudioAndVideoTracks: mockGetAudioAndVideoTracks }));
 
     const wrapper = mount(<PreJoinScreens />);
 
@@ -155,5 +156,6 @@ describe('the PreJoinScreens component', () => {
 
     const error = wrapper.children().prop('subContent').props.children[1].props.error;
     expect(error).toBe('testError');
+    expect(mockGetAudioAndVideoTracks).toHaveBeenCalledTimes(1); // This makes sure that 'getAudioAndVideoTracks' isn't called repeatedly
   });
 });

--- a/src/components/PreJoinScreens/PreJoinScreens.tsx
+++ b/src/components/PreJoinScreens/PreJoinScreens.tsx
@@ -35,14 +35,14 @@ export default function PreJoinScreens() {
   }, [user, URLRoomName]);
 
   useEffect(() => {
-    if (step === Steps.deviceSelectionStep) {
+    if (step === Steps.deviceSelectionStep && !mediaError) {
       getAudioAndVideoTracks().catch(error => {
         console.log('Error acquiring local media:');
         console.dir(error);
         setMediaError(error);
       });
     }
-  }, [getAudioAndVideoTracks, step]);
+  }, [getAudioAndVideoTracks, step, mediaError]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This fixes a bug where `getAudioAndVideoTracks` is called repeatedly when there is a `getUserMedia` error. The repeated calls to `getAudioAndVideoTracks` result in the error message never being displayed to the user. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary