### PR TITLE
Ensure dimension changes invalidate view

### DIFF
--- a/src/hooks/useVideoTrackDimensions/useVideoTrackDimensions.tsx
+++ b/src/hooks/useVideoTrackDimensions/useVideoTrackDimensions.tsx
@@ -10,7 +10,10 @@ export default function useVideoTrackDimensions(track?: TrackType) {
     setDimensions(track?.dimensions);
 
     if (track) {
-      const handleDimensionsChanged = (track: TrackType) => setDimensions(track?.dimensions);
+      const handleDimensionsChanged = (track: TrackType) => setDimensions({
+        width: track.dimensions.width,
+        height: track.dimensions.height
+      });
       track.on('dimensionsChanged', handleDimensionsChanged);
       return () => {
         track.off('dimensionsChanged', handleDimensionsChanged);


### PR DESCRIPTION
The track.dimensions object remains the same throughout the lifespan of the track, but its values are updated. This means that the setter always receives the same object and therefore doesn't result in the state actually changing.

By copying the dimension values into a new object, we ensure that consumers of this hook are always kept up to date with the new dimensions.

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-0000](https://issues.corp.twilio.com/browse/AHOYAPPS-0000)

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary