### PR TITLE
Update useDimensionsChanged hook so that it causes re-render

### DIFF
--- a/src/hooks/useVideoTrackDimensions/useVideoTrackDimensions.test.tsx
+++ b/src/hooks/useVideoTrackDimensions/useVideoTrackDimensions.test.tsx
@@ -30,6 +30,20 @@ describe('the useVideoTrackDimensions hook', () => {
     expect(result.current).toEqual({ height: 300, width: 600 });
   });
 
+  it('should return a new object reference on "dimensionsChanged" event', () => {
+    mockTrack.dimensions = { height: 123, width: 456 };
+    const { result } = renderHook(() => useVideoTrackDimensions(mockTrack));
+
+    act(() => {
+      mockTrack.dimensions.height = 300;
+      mockTrack.dimensions.width = 600;
+      mockTrack.emit('dimensionsChanged', mockTrack);
+    });
+
+    expect(result.current).toEqual({ height: 300, width: 600 });
+    expect(result.current).not.toBe(mockTrack.dimensions);
+  });
+
   it('should clean up listeners on unmount', () => {
     const { unmount } = renderHook(() => useVideoTrackDimensions(mockTrack));
     unmount();

--- a/src/hooks/useVideoTrackDimensions/useVideoTrackDimensions.tsx
+++ b/src/hooks/useVideoTrackDimensions/useVideoTrackDimensions.tsx
@@ -10,7 +10,10 @@ export default function useVideoTrackDimensions(track?: TrackType) {
     setDimensions(track?.dimensions);
 
     if (track) {
-      const handleDimensionsChanged = (track: TrackType) => setDimensions(track?.dimensions);
+      const handleDimensionsChanged = (track: TrackType) => setDimensions({
+        width: track.dimensions.width,
+        height: track.dimensions.height
+      });
       track.on('dimensionsChanged', handleDimensionsChanged);
       return () => {
         track.off('dimensionsChanged', handleDimensionsChanged);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This pull request contains a bugfix submitted by Github user @tomhicks. I've pulled his changes into a new PR so that the Circle CI tests can run on it. Here is the original PR: https://github.com/twilio/twilio-video-app-react/pull/376

This PR fixes an issue found in the `useDimensionsChanged` hook, where the `handleDimensionsChanged` function would set the same object reference as the one already stored in the hook's state. This means that component that use this hook would not re-render when a track's dimensions have changed. 

`handleDimensionsChanged` now returns a new object reference when a track's dimensions have changed, which will correctly cause components to re-render.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary