### PR TITLE
Fix sidebar flicker

### DIFF
--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -11,7 +11,6 @@ import useScreenShareParticipant from '../../hooks/useScreenShareParticipant/use
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
-      padding: '2em',
       overflowY: 'auto',
       background: 'rgb(79, 83, 85)',
       gridArea: '1 / 2 / 1 / 3',
@@ -21,14 +20,21 @@ const useStyles = makeStyles((theme: Theme) =>
         overflowY: 'initial',
         overflowX: 'auto',
         display: 'flex',
-        padding: `${theme.sidebarMobilePadding}px`,
       },
     },
     transparentBackground: {
       background: 'transparent',
     },
     scrollContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+    },
+    innerScrollContainer: {
+      width: `calc(${theme.sidebarWidth}px - 4em)`,
+      padding: '2em 0',
       [theme.breakpoints.down('sm')]: {
+        width: 'auto',
+        padding: `${theme.sidebarMobilePadding}px`,
         display: 'flex',
       },
     },
@@ -55,21 +61,23 @@ export default function ParticipantList() {
       })}
     >
       <div className={classes.scrollContainer}>
-        <Participant participant={localParticipant} isLocalParticipant={true} />
-        {participants.map(participant => {
-          const isSelected = participant === selectedParticipant;
-          const hideParticipant =
-            participant === mainParticipant && participant !== screenShareParticipant && !isSelected;
-          return (
-            <Participant
-              key={participant.sid}
-              participant={participant}
-              isSelected={participant === selectedParticipant}
-              onClick={() => setSelectedParticipant(participant)}
-              hideParticipant={hideParticipant}
-            />
-          );
-        })}
+        <div className={classes.innerScrollContainer}>
+          <Participant participant={localParticipant} isLocalParticipant={true} />
+          {participants.map(participant => {
+            const isSelected = participant === selectedParticipant;
+            const hideParticipant =
+              participant === mainParticipant && participant !== screenShareParticipant && !isSelected;
+            return (
+              <Participant
+                key={participant.sid}
+                participant={participant}
+                isSelected={participant === selectedParticipant}
+                onClick={() => setSelectedParticipant(participant)}
+                hideParticipant={hideParticipant}
+              />
+            );
+          })}
+        </div>
       </div>
     </aside>
   );

--- a/src/components/ParticipantList/__snapshots__/ParticipantList.test.tsx.snap
+++ b/src/components/ParticipantList/__snapshots__/ParticipantList.test.tsx.snap
@@ -7,43 +7,47 @@ exports[`the ParticipantList component should correctly render Participant compo
   <div
     className="makeStyles-scrollContainer-3"
   >
-    <Participant
-      isLocalParticipant={true}
-      participant="localParticipant"
-    />
-    <Participant
-      hideParticipant={false}
-      isSelected={false}
-      key="0"
-      onClick={[Function]}
-      participant={
-        Object {
-          "sid": 0,
+    <div
+      className="makeStyles-innerScrollContainer-4"
+    >
+      <Participant
+        isLocalParticipant={true}
+        participant="localParticipant"
+      />
+      <Participant
+        hideParticipant={false}
+        isSelected={false}
+        key="0"
+        onClick={[Function]}
+        participant={
+          Object {
+            "sid": 0,
+          }
         }
-      }
-    />
-    <Participant
-      hideParticipant={false}
-      isSelected={false}
-      key="1"
-      onClick={[Function]}
-      participant={
-        Object {
-          "sid": 1,
+      />
+      <Participant
+        hideParticipant={false}
+        isSelected={false}
+        key="1"
+        onClick={[Function]}
+        participant={
+          Object {
+            "sid": 1,
+          }
         }
-      }
-    />
-    <Participant
-      hideParticipant={false}
-      isSelected={true}
-      key="2"
-      onClick={[Function]}
-      participant={
-        Object {
-          "sid": 2,
+      />
+      <Participant
+        hideParticipant={false}
+        isSelected={true}
+        key="2"
+        onClick={[Function]}
+        participant={
+          Object {
+            "sid": 2,
+          }
         }
-      }
-    />
+      />
+    </div>
   </div>
 </aside>
 `;


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR fixes the flicker that is sometimes seen in the participant sidebar when the browser window just short enough to make the scrollbar appear. 

Before:
![Flicker](https://user-images.githubusercontent.com/12685223/105108302-2eefaf00-5a77-11eb-9f85-8b1d263e3f53.gif)

After:
![noflicker](https://user-images.githubusercontent.com/12685223/105108344-42027f00-5a77-11eb-8222-7a6fbb672df6.gif)

The flicker is caused by a CSS infinite loop. When the scrollbar appears in the sidebar, it reduces the width of the participant thumbnails, which reduces their height (to preserve aspect ratio), which reduces the length of the list, which removes the scroll bar, which increases the width of the participant thumbnails, which increases their length, and so on.

This fix adds an additional div in the sidebar (the 'innerScrollContainer'). Now, when the scrollbar appears, it reduces the size of the innerScrollContainer and not the participant thumbnails. 

Note: To reproduce this issue on a Mac laptop, you must have an external mouse connected. Having an external mouse connected can change the styling of the scrollbars that appear. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary