### PR TITLE
Stop screensharing on disconnect

### DIFF
--- a/src/components/Buttons/EndCallButton/EndCallButton.test.tsx
+++ b/src/components/Buttons/EndCallButton/EndCallButton.test.tsx
@@ -8,7 +8,6 @@ const mockVideoContext = {
     disconnect: jest.fn(),
   },
   isSharingScreen: false,
-  toggleScreenShare: jest.fn(),
   removeLocalAudioTrack: jest.fn(),
   removeLocalVideoTrack: jest.fn(),
 };
@@ -22,7 +21,6 @@ describe('End Call button', () => {
 
       beforeAll(() => {
         jest.clearAllMocks();
-        mockVideoContext.isSharingScreen = true;
         wrapper = shallow(<EndCallButton />);
         wrapper.simulate('click');
       });
@@ -35,27 +33,8 @@ describe('End Call button', () => {
         expect(mockVideoContext.removeLocalVideoTrack).toHaveBeenCalled();
       });
 
-      it('should toggle screen sharing off', () => {
-        expect(mockVideoContext.toggleScreenShare).toHaveBeenCalled();
-      });
-
       it('should disconnect from the room ', () => {
         expect(mockVideoContext.room.disconnect).toHaveBeenCalled();
-      });
-    });
-
-    describe('while not sharing screen', () => {
-      let wrapper;
-
-      beforeAll(() => {
-        jest.clearAllMocks();
-        mockVideoContext.isSharingScreen = false;
-        wrapper = shallow(<EndCallButton />);
-        wrapper.simulate('click');
-      });
-
-      it('should not toggle screen sharing', () => {
-        expect(mockVideoContext.toggleScreenShare).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/components/Buttons/EndCallButton/EndCallButton.test.tsx
+++ b/src/components/Buttons/EndCallButton/EndCallButton.test.tsx
@@ -7,35 +7,14 @@ const mockVideoContext = {
   room: {
     disconnect: jest.fn(),
   },
-  isSharingScreen: false,
-  removeLocalAudioTrack: jest.fn(),
-  removeLocalVideoTrack: jest.fn(),
 };
 
 jest.mock('../../../hooks/useVideoContext/useVideoContext', () => () => mockVideoContext);
 
 describe('End Call button', () => {
-  describe('when it is clicked', () => {
-    describe('while sharing screen', () => {
-      let wrapper;
-
-      beforeAll(() => {
-        jest.clearAllMocks();
-        wrapper = shallow(<EndCallButton />);
-        wrapper.simulate('click');
-      });
-
-      it('should stop local audio tracks', () => {
-        expect(mockVideoContext.removeLocalAudioTrack).toHaveBeenCalled();
-      });
-
-      it('should stop local video tracks', () => {
-        expect(mockVideoContext.removeLocalVideoTrack).toHaveBeenCalled();
-      });
-
-      it('should disconnect from the room ', () => {
-        expect(mockVideoContext.room.disconnect).toHaveBeenCalled();
-      });
-    });
+  it('should disconnect from the room when clicked', () => {
+    const wrapper = shallow(<EndCallButton />);
+    wrapper.simulate('click');
+    expect(mockVideoContext.room.disconnect).toHaveBeenCalled();
   });
 });

--- a/src/components/Buttons/EndCallButton/EndCallButton.tsx
+++ b/src/components/Buttons/EndCallButton/EndCallButton.tsx
@@ -20,16 +20,10 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function EndCallButton(props: { className?: string }) {
   const classes = useStyles();
-  const { room, removeLocalAudioTrack, removeLocalVideoTrack } = useVideoContext();
-
-  const handleClick = () => {
-    removeLocalAudioTrack();
-    removeLocalVideoTrack();
-    room!.disconnect();
-  };
+  const { room } = useVideoContext();
 
   return (
-    <Button onClick={handleClick} className={clsx(classes.button, props.className)} data-cy-disconnect>
+    <Button onClick={() => room!.disconnect()} className={clsx(classes.button, props.className)} data-cy-disconnect>
       Disconnect
     </Button>
   );

--- a/src/components/Buttons/EndCallButton/EndCallButton.tsx
+++ b/src/components/Buttons/EndCallButton/EndCallButton.tsx
@@ -20,12 +20,9 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function EndCallButton(props: { className?: string }) {
   const classes = useStyles();
-  const { room, isSharingScreen, toggleScreenShare, removeLocalAudioTrack, removeLocalVideoTrack } = useVideoContext();
+  const { room, removeLocalAudioTrack, removeLocalVideoTrack } = useVideoContext();
 
   const handleClick = () => {
-    if (isSharingScreen) {
-      toggleScreenShare();
-    }
     removeLocalAudioTrack();
     removeLocalVideoTrack();
     room!.disconnect();

--- a/src/components/VideoProvider/index.test.tsx
+++ b/src/components/VideoProvider/index.test.tsx
@@ -5,7 +5,7 @@ import { Room, TwilioError } from 'twilio-video';
 import { VideoProvider } from './index';
 import useLocalTracks from './useLocalTracks/useLocalTracks';
 import useRoom from './useRoom/useRoom';
-import useHandleRoomDisconnectionErrors from './useHandleRoomDisconnectionErrors/useHandleRoomDisconnectionErrors';
+import useHandleRoomDisconnection from './useHandleRoomDisconnection/useHandleRoomDisconnection';
 import useHandleTrackPublicationFailed from './useHandleTrackPublicationFailed/useHandleTrackPublicationFailed';
 import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
 
@@ -17,10 +17,11 @@ jest.mock('./useLocalTracks/useLocalTracks', () =>
     getLocalVideoTrack: () => {},
     getLocalAudioTrack: () => {},
     isAcquiringLocalTracks: true,
+    removeLocalAudioTrack: () => {},
     removeLocalVideoTrack: () => {},
   }))
 );
-jest.mock('./useHandleRoomDisconnectionErrors/useHandleRoomDisconnectionErrors');
+jest.mock('./useHandleRoomDisconnection/useHandleRoomDisconnection');
 jest.mock('./useHandleTrackPublicationFailed/useHandleTrackPublicationFailed');
 
 describe('the VideoProvider component', () => {
@@ -47,7 +48,14 @@ describe('the VideoProvider component', () => {
       dominantSpeaker: true,
     });
     expect(useLocalTracks).toHaveBeenCalled();
-    expect(useHandleRoomDisconnectionErrors).toHaveBeenCalledWith(mockRoom, expect.any(Function));
+    expect(useHandleRoomDisconnection).toHaveBeenCalledWith(
+      mockRoom,
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      false,
+      expect.any(Function)
+    );
     expect(useHandleTrackPublicationFailed).toHaveBeenCalledWith(mockRoom, expect.any(Function));
   });
 

--- a/src/components/VideoProvider/index.tsx
+++ b/src/components/VideoProvider/index.tsx
@@ -11,7 +11,7 @@ import { ErrorCallback } from '../../types';
 import { SelectedParticipantProvider } from './useSelectedParticipant/useSelectedParticipant';
 
 import AttachVisibilityHandler from './AttachVisibilityHandler/AttachVisibilityHandler';
-import useHandleRoomDisconnectionErrors from './useHandleRoomDisconnectionErrors/useHandleRoomDisconnectionErrors';
+import useHandleRoomDisconnection from './useHandleRoomDisconnection/useHandleRoomDisconnection';
 import useHandleTrackPublicationFailed from './useHandleTrackPublicationFailed/useHandleTrackPublicationFailed';
 import useLocalTracks from './useLocalTracks/useLocalTracks';
 import useRoom from './useRoom/useRoom';
@@ -33,7 +33,6 @@ export interface IVideoContext {
   getLocalVideoTrack: (newOptions?: CreateLocalTrackOptions) => Promise<LocalVideoTrack>;
   getLocalAudioTrack: (deviceId?: string) => Promise<LocalAudioTrack>;
   isAcquiringLocalTracks: boolean;
-  removeLocalAudioTrack: () => void;
   removeLocalVideoTrack: () => void;
   isSharingScreen: boolean;
   toggleScreenShare: () => void;
@@ -65,10 +64,18 @@ export function VideoProvider({ options, children, onError = () => {} }: VideoPr
   } = useLocalTracks();
   const { room, isConnecting, connect } = useRoom(localTracks, onErrorCallback, options);
 
-  // Register onError callback functions.
-  useHandleRoomDisconnectionErrors(room, onError);
-  useHandleTrackPublicationFailed(room, onError);
   const [isSharingScreen, toggleScreenShare] = useScreenShareToggle(room, onError);
+
+  // Register onError callback functions.
+  useHandleRoomDisconnection(
+    room,
+    onError,
+    removeLocalAudioTrack,
+    removeLocalVideoTrack,
+    isSharingScreen,
+    toggleScreenShare
+  );
+  useHandleTrackPublicationFailed(room, onError);
 
   return (
     <VideoContext.Provider
@@ -81,7 +88,6 @@ export function VideoProvider({ options, children, onError = () => {} }: VideoPr
         getLocalAudioTrack,
         connect,
         isAcquiringLocalTracks,
-        removeLocalAudioTrack,
         removeLocalVideoTrack,
         isSharingScreen,
         toggleScreenShare,

--- a/src/components/VideoProvider/index.tsx
+++ b/src/components/VideoProvider/index.tsx
@@ -66,7 +66,7 @@ export function VideoProvider({ options, children, onError = () => {} }: VideoPr
 
   const [isSharingScreen, toggleScreenShare] = useScreenShareToggle(room, onError);
 
-  // Register onError callback functions.
+  // Register callback functions to be called on room disconnect.
   useHandleRoomDisconnection(
     room,
     onError,

--- a/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
+++ b/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
@@ -4,30 +4,118 @@ import EventEmitter from 'events';
 import useHandleRoomDisconnection from './useHandleRoomDisconnection';
 import { Room } from 'twilio-video';
 
+const mockOnError = jest.fn();
+const mockRemoveLocalAudioTrack = jest.fn();
+const mockRemoveLocalVideoTrack = jest.fn();
+const mockToggleScreenSharing = jest.fn();
+
 describe('the useHandleRoomDisconnection hook', () => {
   let mockRoom: any = new EventEmitter();
 
+  beforeEach(jest.clearAllMocks);
+
   it('should do nothing if the room emits a "disconnected" event with no error', () => {
-    const mockOnError = jest.fn();
-    renderHook(() => useHandleRoomDisconnection(mockRoom, mockOnError));
+    renderHook(() =>
+      useHandleRoomDisconnection(
+        mockRoom,
+        mockOnError,
+        mockRemoveLocalAudioTrack,
+        mockRemoveLocalVideoTrack,
+        false,
+        mockToggleScreenSharing
+      )
+    );
     act(() => {
-      mockRoom.emit('disconnected', 'disconnected');
+      mockRoom.emit('disconnected', mockRoom);
     });
     expect(mockOnError).not.toHaveBeenCalled();
   });
 
   it('should react to the rooms "disconnected" event and invoke onError callback if there is an error', () => {
     const mockOnError = jest.fn();
-    renderHook(() => useHandleRoomDisconnection(mockRoom, mockOnError));
+    renderHook(() =>
+      useHandleRoomDisconnection(
+        mockRoom,
+        mockOnError,
+        mockRemoveLocalAudioTrack,
+        mockRemoveLocalVideoTrack,
+        false,
+        mockToggleScreenSharing
+      )
+    );
     act(() => {
-      mockRoom.emit('disconnected', 'disconnected', 'mockError');
+      mockRoom.emit('disconnected', mockRoom, 'mockError');
     });
     expect(mockOnError).toHaveBeenCalledWith('mockError');
   });
 
+  it('should remove local tracks when the "disconnected" event is emitted', () => {
+    const mockOnError = jest.fn();
+    renderHook(() =>
+      useHandleRoomDisconnection(
+        mockRoom,
+        mockOnError,
+        mockRemoveLocalAudioTrack,
+        mockRemoveLocalVideoTrack,
+        false,
+        mockToggleScreenSharing
+      )
+    );
+    act(() => {
+      mockRoom.emit('disconnected', mockRoom, 'mockError');
+    });
+    expect(mockRemoveLocalAudioTrack).toHaveBeenCalled();
+    expect(mockRemoveLocalVideoTrack).toHaveBeenCalled();
+  });
+
+  it('should not toggle screensharing when the "disconnected" event is emitted and isSharing is false', () => {
+    const mockOnError = jest.fn();
+    renderHook(() =>
+      useHandleRoomDisconnection(
+        mockRoom,
+        mockOnError,
+        mockRemoveLocalAudioTrack,
+        mockRemoveLocalVideoTrack,
+        false,
+        mockToggleScreenSharing
+      )
+    );
+    act(() => {
+      mockRoom.emit('disconnected', mockRoom, 'mockError');
+    });
+    expect(mockToggleScreenSharing).not.toHaveBeenCalled();
+  });
+
+  it('should toggle screensharing when the "disconnected" event is emitted and isSharing is true', () => {
+    const mockOnError = jest.fn();
+    renderHook(() =>
+      useHandleRoomDisconnection(
+        mockRoom,
+        mockOnError,
+        mockRemoveLocalAudioTrack,
+        mockRemoveLocalVideoTrack,
+        true,
+        mockToggleScreenSharing
+      )
+    );
+    act(() => {
+      mockRoom.emit('disconnected', mockRoom, 'mockError');
+    });
+    expect(mockToggleScreenSharing).toHaveBeenCalled();
+  });
+
   it('should tear down old listeners when receiving a new room', () => {
     const originalMockRoom = mockRoom;
-    const { rerender } = renderHook(() => useHandleRoomDisconnection(mockRoom, () => {}));
+    const { rerender } = renderHook(() =>
+      useHandleRoomDisconnection(
+        mockRoom,
+        mockOnError,
+        mockRemoveLocalAudioTrack,
+        mockRemoveLocalVideoTrack,
+        false,
+        mockToggleScreenSharing
+      )
+    );
     expect(originalMockRoom.listenerCount('disconnected')).toBe(1);
 
     act(() => {
@@ -41,7 +129,16 @@ describe('the useHandleRoomDisconnection hook', () => {
   });
 
   it('should clean up listeners on unmount', () => {
-    const { unmount } = renderHook(() => useHandleRoomDisconnection(mockRoom, () => {}));
+    const { unmount } = renderHook(() =>
+      useHandleRoomDisconnection(
+        mockRoom,
+        mockOnError,
+        mockRemoveLocalAudioTrack,
+        mockRemoveLocalVideoTrack,
+        false,
+        mockToggleScreenSharing
+      )
+    );
     unmount();
     expect(mockRoom.listenerCount('disconnected')).toBe(0);
   });

--- a/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
+++ b/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
@@ -1,15 +1,15 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import EventEmitter from 'events';
 
-import useHandleRoomDisconnectionErrors from './useHandleRoomDisconnectionErrors';
+import useHandleRoomDisconnection from './useHandleRoomDisconnection';
 import { Room } from 'twilio-video';
 
-describe('the useHandleRoomDisconnectionErrors hook', () => {
+describe('the useHandleRoomDisconnection hook', () => {
   let mockRoom: any = new EventEmitter();
 
   it('should do nothing if the room emits a "disconnected" event with no error', () => {
     const mockOnError = jest.fn();
-    renderHook(() => useHandleRoomDisconnectionErrors(mockRoom, mockOnError));
+    renderHook(() => useHandleRoomDisconnection(mockRoom, mockOnError));
     act(() => {
       mockRoom.emit('disconnected', 'disconnected');
     });
@@ -18,7 +18,7 @@ describe('the useHandleRoomDisconnectionErrors hook', () => {
 
   it('should react to the rooms "disconnected" event and invoke onError callback if there is an error', () => {
     const mockOnError = jest.fn();
-    renderHook(() => useHandleRoomDisconnectionErrors(mockRoom, mockOnError));
+    renderHook(() => useHandleRoomDisconnection(mockRoom, mockOnError));
     act(() => {
       mockRoom.emit('disconnected', 'disconnected', 'mockError');
     });
@@ -27,7 +27,7 @@ describe('the useHandleRoomDisconnectionErrors hook', () => {
 
   it('should tear down old listeners when receiving a new room', () => {
     const originalMockRoom = mockRoom;
-    const { rerender } = renderHook(() => useHandleRoomDisconnectionErrors(mockRoom, () => {}));
+    const { rerender } = renderHook(() => useHandleRoomDisconnection(mockRoom, () => {}));
     expect(originalMockRoom.listenerCount('disconnected')).toBe(1);
 
     act(() => {
@@ -41,7 +41,7 @@ describe('the useHandleRoomDisconnectionErrors hook', () => {
   });
 
   it('should clean up listeners on unmount', () => {
-    const { unmount } = renderHook(() => useHandleRoomDisconnectionErrors(mockRoom, () => {}));
+    const { unmount } = renderHook(() => useHandleRoomDisconnection(mockRoom, () => {}));
     unmount();
     expect(mockRoom.listenerCount('disconnected')).toBe(0);
   });

--- a/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
+++ b/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
@@ -32,7 +32,6 @@ describe('the useHandleRoomDisconnection hook', () => {
   });
 
   it('should react to the rooms "disconnected" event and invoke onError callback if there is an error', () => {
-    const mockOnError = jest.fn();
     renderHook(() =>
       useHandleRoomDisconnection(
         mockRoom,
@@ -50,7 +49,6 @@ describe('the useHandleRoomDisconnection hook', () => {
   });
 
   it('should remove local tracks when the "disconnected" event is emitted', () => {
-    const mockOnError = jest.fn();
     renderHook(() =>
       useHandleRoomDisconnection(
         mockRoom,
@@ -69,7 +67,6 @@ describe('the useHandleRoomDisconnection hook', () => {
   });
 
   it('should not toggle screensharing when the "disconnected" event is emitted and isSharing is false', () => {
-    const mockOnError = jest.fn();
     renderHook(() =>
       useHandleRoomDisconnection(
         mockRoom,
@@ -87,7 +84,6 @@ describe('the useHandleRoomDisconnection hook', () => {
   });
 
   it('should toggle screensharing when the "disconnected" event is emitted and isSharing is true', () => {
-    const mockOnError = jest.fn();
     renderHook(() =>
       useHandleRoomDisconnection(
         mockRoom,

--- a/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
+++ b/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.test.tsx
@@ -1,8 +1,7 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import EventEmitter from 'events';
-
-import useHandleRoomDisconnection from './useHandleRoomDisconnection';
 import { Room } from 'twilio-video';
+import EventEmitter from 'events';
+import useHandleRoomDisconnection from './useHandleRoomDisconnection';
 
 const mockOnError = jest.fn();
 const mockRemoveLocalAudioTrack = jest.fn();

--- a/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.ts
+++ b/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.ts
@@ -3,12 +3,25 @@ import { useEffect } from 'react';
 
 import { Callback } from '../../../types';
 
-export default function useHandleRoomDisconnection(room: Room | null, onError: Callback) {
+export default function useHandleRoomDisconnection(
+  room: Room | null,
+  onError: Callback,
+  removeLocalAudioTrack: () => void,
+  removeLocalVideoTrack: () => void,
+  isSharingScreen: boolean,
+  toggleScreenShare: () => void
+) {
   useEffect(() => {
     if (room) {
       const onDisconnected = (_: Room, error: TwilioError) => {
         if (error) {
           onError(error);
+        }
+
+        removeLocalAudioTrack();
+        removeLocalVideoTrack();
+        if (isSharingScreen) {
+          toggleScreenShare();
         }
       };
 
@@ -17,5 +30,5 @@ export default function useHandleRoomDisconnection(room: Room | null, onError: C
         room.off('disconnected', onDisconnected);
       };
     }
-  }, [room, onError]);
+  }, [room, onError, removeLocalAudioTrack, removeLocalVideoTrack, isSharingScreen, toggleScreenShare]);
 }

--- a/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.ts
+++ b/src/components/VideoProvider/useHandleRoomDisconnection/useHandleRoomDisconnection.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 
 import { Callback } from '../../../types';
 
-export default function useHandleRoomDisconnectionErrors(room: Room | null, onError: Callback) {
+export default function useHandleRoomDisconnection(room: Room | null, onError: Callback) {
   useEffect(() => {
     if (room) {
       const onDisconnected = (_: Room, error: TwilioError) => {

--- a/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.test.tsx
+++ b/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.test.tsx
@@ -7,8 +7,9 @@ const mockLocalParticipant = new EventEmitter() as any;
 mockLocalParticipant.publishTrack = jest.fn(() => Promise.resolve('mockPublication'));
 mockLocalParticipant.unpublishTrack = jest.fn();
 
-const mockRoom = new EventEmitter() as any;
-mockRoom.localParticipant = mockLocalParticipant;
+const mockRoom = {
+  localParticipant: mockLocalParticipant,
+} as any;
 
 const mockOnError: ErrorCallback = () => {};
 

--- a/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.test.tsx
+++ b/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.test.tsx
@@ -70,21 +70,6 @@ describe('the useScreenShareToggle hook', () => {
       expect(result.current[0]).toEqual(false);
     });
 
-    it('should correctly stop screen sharing when disconnected from the room', async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useScreenShareToggle(mockRoom, mockOnError));
-      expect(mockTrack.onended).toBeUndefined();
-      result.current[1]();
-      await waitForNextUpdate();
-      expect(result.current[0]).toEqual(true);
-      act(() => {
-        mockRoom.emit('disconnected');
-      });
-      expect(mockLocalParticipant.unpublishTrack).toHaveBeenCalledWith(mockTrack);
-      expect(mockLocalParticipant.unpublishTrack).toHaveBeenCalledWith(mockTrack);
-      expect(mockTrack.stop).toHaveBeenCalled();
-      expect(result.current[0]).toEqual(false);
-    });
-
     describe('onended function', () => {
       it('should correctly stop screen sharing when called', async () => {
         const localParticipantSpy = jest.spyOn(mockLocalParticipant, 'emit');

--- a/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
+++ b/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { LogLevels, Track, Room } from 'twilio-video';
 import { ErrorCallback } from '../../../types';
 
@@ -60,6 +60,21 @@ export default function useScreenShareToggle(room: Room | null, onError: ErrorCa
       !isSharing ? shareScreen() : stopScreenShareRef.current();
     }
   }, [isSharing, shareScreen, stopScreenShareRef, room]);
+
+  useEffect(() => {
+    if (room) {
+      const handleDisconnect = () => {
+        if (isSharing) {
+          stopScreenShareRef.current();
+        }
+      };
+
+      room.on('disconnected', handleDisconnect);
+      return () => {
+        room.off('disconnected', handleDisconnect);
+      };
+    }
+  }, [room, isSharing]);
 
   return [isSharing, toggleScreenShare] as const;
 }

--- a/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
+++ b/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
@@ -61,20 +61,5 @@ export default function useScreenShareToggle(room: Room | null, onError: ErrorCa
     }
   }, [isSharing, shareScreen, stopScreenShareRef, room]);
 
-  useEffect(() => {
-    if (room) {
-      const handleDisconnect = () => {
-        if (isSharing) {
-          stopScreenShareRef.current();
-        }
-      };
-
-      room.on('disconnected', handleDisconnect);
-      return () => {
-        room.off('disconnected', handleDisconnect);
-      };
-    }
-  }, [room, isSharing]);
-
   return [isSharing, toggleScreenShare] as const;
 }

--- a/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
+++ b/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { LogLevels, Track, Room } from 'twilio-video';
 import { ErrorCallback } from '../../../types';
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-4365](https://issues.corp.twilio.com/browse/VIDEO-4365)

### Description

This PR stops all tracks (audio, video, and screen share) when the user is disconnected from the room for any reason (network disconnection, or clicking the 'Disconnect' button). Previously, the tracks were only stopped when the user clicked on the Disconnect button.

Resolves #444 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary