### PR TITLE
Chat notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lint": "eslint src server",
     "server": "ts-node -T -P server/tsconfig.json server/index.ts",
     "typescript:server": "tsc --noEmit -p server/",
-    "test:ci": "jest --ci --runInBand --reporters=default --reporters=jest-junit --coverage",
+    "test:ci": "cross-env TZ=utc jest --ci --runInBand --reporters=default --reporters=jest-junit --coverage",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --browser chrome",
     "cypress:ci": "cross-env CYPRESS_baseUrl=http://localhost:8081 start-server-and-test server http://localhost:8081 cypress:run",

--- a/src/components/Buttons/ToggleChatButton/ToggleChatButton.test.tsx
+++ b/src/components/Buttons/ToggleChatButton/ToggleChatButton.test.tsx
@@ -1,27 +1,119 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import { Button } from '@material-ui/core';
+import { EventEmitter } from 'events';
+import { shallow, mount } from 'enzyme';
 
 import ChatIcon from '../../../icons/ChatIcon';
-import ToggleChatButton from './ToggleChatButton';
+import ToggleChatButton, { ANIMATION_DURATION } from './ToggleChatButton';
 import useChatContext from '../../../hooks/useChatContext/useChatContext';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('../../../hooks/useChatContext/useChatContext');
 const mockUseChatContext = useChatContext as jest.Mock<any>;
 
+const mockConversation = new EventEmitter();
 const mockToggleChatWindow = jest.fn();
-mockUseChatContext.mockImplementation(() => ({ setIsChatWindowOpen: mockToggleChatWindow, isChatWindowOpen: false }));
+mockUseChatContext.mockImplementation(() => ({
+  setIsChatWindowOpen: mockToggleChatWindow,
+  isChatWindowOpen: false,
+  conversation: mockConversation,
+}));
 
 describe('the ToggleChatButton component', () => {
-  it('should render correctly when chat is enabled', () => {
+  it('should be enabled when a conversation is present', () => {
     const wrapper = shallow(<ToggleChatButton />);
-    expect(wrapper.prop('startIcon')).toEqual(<ChatIcon />);
-    expect(wrapper.text()).toBe('Chat');
+    expect(wrapper.prop('disabled')).toBe(false);
+  });
+
+  it('should be disabled when a conversation is not present', () => {
+    mockUseChatContext.mockImplementationOnce(() => ({
+      setIsChatWindowOpen: mockToggleChatWindow,
+      isChatWindowOpen: false,
+      conversation: null,
+    }));
+    const wrapper = shallow(<ToggleChatButton />);
+    expect(wrapper.prop('disabled')).toBe(true);
   });
 
   it('should call the correct toggle function when clicked', () => {
     const wrapper = shallow(<ToggleChatButton />);
     wrapper.find(Button).simulate('click');
     expect(mockToggleChatWindow).toHaveBeenCalledWith(true);
+  });
+
+  it('should show an indicator when there are unread messages', () => {
+    mockUseChatContext.mockImplementationOnce(() => ({
+      setIsChatWindowOpen: mockToggleChatWindow,
+      isChatWindowOpen: false,
+      conversation: mockConversation,
+      hasUnreadMessages: true,
+    }));
+
+    const wrapper = mount(<ToggleChatButton />);
+    const notificationCircle = wrapper.findWhere(node => node.prop('className')?.includes('circle'));
+    expect(notificationCircle.prop('className')).toContain('hasUnreadMessages');
+  });
+
+  it('should not show an indicator when there are no unread messages', () => {
+    mockUseChatContext.mockImplementationOnce(() => ({
+      setIsChatWindowOpen: mockToggleChatWindow,
+      isChatWindowOpen: false,
+      conversation: mockConversation,
+      hasUnreadMessages: false,
+    }));
+
+    const wrapper = mount(<ToggleChatButton />);
+    const notificationCircle = wrapper.findWhere(node => node.prop('className')?.includes('circle'));
+    expect(notificationCircle.prop('className')).not.toContain('hasUnreadMessages');
+  });
+
+  it(`should add the 'animate' class for ${ANIMATION_DURATION}ms when a new message is received when the chat window is closed`, () => {
+    jest.useFakeTimers();
+    mockUseChatContext.mockImplementationOnce(() => ({
+      setIsChatWindowOpen: mockToggleChatWindow,
+      isChatWindowOpen: false,
+      conversation: mockConversation,
+    }));
+
+    const wrapper = mount(<ToggleChatButton />);
+    let notificationRing = wrapper.findWhere(node => node.prop('className')?.includes('ring'));
+    expect(notificationRing.prop('className')).not.toContain('animate');
+
+    act(() => {
+      mockConversation.emit('messageAdded');
+    });
+    wrapper.update();
+
+    notificationRing = wrapper.findWhere(node => node.prop('className')?.includes('ring'));
+    expect(notificationRing.prop('className')).toContain('animate');
+
+    act(() => {
+      jest.advanceTimersByTime(ANIMATION_DURATION);
+    });
+    wrapper.update();
+
+    notificationRing = wrapper.findWhere(node => node.prop('className')?.includes('ring'));
+    expect(notificationRing.prop('className')).not.toContain('animate');
+  });
+
+  it(`should not add the 'animate' class when a new message is received when the chat window is open`, () => {
+    jest.useFakeTimers();
+    mockUseChatContext.mockImplementationOnce(() => ({
+      setIsChatWindowOpen: mockToggleChatWindow,
+      isChatWindowOpen: open,
+      conversation: mockConversation,
+    }));
+
+    const wrapper = mount(<ToggleChatButton />);
+    let notificationRing = wrapper.findWhere(node => node.prop('className')?.includes('ring'));
+    expect(notificationRing.prop('className')).not.toContain('animate');
+
+    act(() => {
+      mockConversation.emit('messageAdded');
+    });
+    wrapper.update();
+
+    notificationRing = wrapper.findWhere(node => node.prop('className')?.includes('ring'));
+    expect(notificationRing.prop('className')).not.toContain('animate');
   });
 });

--- a/src/components/Buttons/ToggleChatButton/ToggleChatButton.test.tsx
+++ b/src/components/Buttons/ToggleChatButton/ToggleChatButton.test.tsx
@@ -98,7 +98,7 @@ describe('the ToggleChatButton component', () => {
   it(`should not add the 'animate' class when a new message is received when the chat window is open`, () => {
     mockUseChatContext.mockImplementationOnce(() => ({
       setIsChatWindowOpen: mockToggleChatWindow,
-      isChatWindowOpen: open,
+      isChatWindowOpen: true,
       conversation: mockConversation,
     }));
 

--- a/src/components/Buttons/ToggleChatButton/ToggleChatButton.test.tsx
+++ b/src/components/Buttons/ToggleChatButton/ToggleChatButton.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { Button } from '@material-ui/core';
 import { EventEmitter } from 'events';
 import { shallow, mount } from 'enzyme';
 
-import ChatIcon from '../../../icons/ChatIcon';
 import ToggleChatButton, { ANIMATION_DURATION } from './ToggleChatButton';
 import useChatContext from '../../../hooks/useChatContext/useChatContext';
-import { act } from 'react-dom/test-utils';
 
 jest.mock('../../../hooks/useChatContext/useChatContext');
 const mockUseChatContext = useChatContext as jest.Mock<any>;
@@ -97,7 +96,6 @@ describe('the ToggleChatButton component', () => {
   });
 
   it(`should not add the 'animate' class when a new message is received when the chat window is open`, () => {
-    jest.useFakeTimers();
     mockUseChatContext.mockImplementationOnce(() => ({
       setIsChatWindowOpen: mockToggleChatWindow,
       isChatWindowOpen: open,

--- a/src/components/Buttons/ToggleChatButton/ToggleChatButton.tsx
+++ b/src/components/Buttons/ToggleChatButton/ToggleChatButton.tsx
@@ -1,17 +1,97 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Button from '@material-ui/core/Button';
 import ChatIcon from '../../../icons/ChatIcon';
+import clsx from 'clsx';
+import { makeStyles } from '@material-ui/core';
 import useChatContext from '../../../hooks/useChatContext/useChatContext';
 
+export const ANIMATION_DURATION = 700;
+
+const useStyles = makeStyles({
+  iconContainer: {
+    position: 'relative',
+    display: 'flex',
+  },
+  circle: {
+    width: '10px',
+    height: '10px',
+    backgroundColor: '#5BB75B',
+    borderRadius: '50%',
+    position: 'absolute',
+    top: '-3px',
+    left: '13px',
+    opacity: 0,
+    transition: `opacity ${ANIMATION_DURATION * 0.5}ms ease-in`,
+  },
+  hasUnreadMessages: {
+    opacity: 1,
+  },
+  ring: {
+    border: '3px solid #62bd19',
+    borderRadius: '30px',
+    height: '14px',
+    width: '14px',
+    position: 'absolute',
+    left: '11px',
+    top: '-5px',
+    opacity: 0,
+  },
+  animateRing: {
+    animation: `$expand ${ANIMATION_DURATION}ms ease-out`,
+    animationIterationCount: 1,
+  },
+  '@keyframes expand': {
+    '0%': {
+      transform: 'scale(0.1, 0.1)',
+      opacity: 0,
+    },
+    '50%': {
+      opacity: 1,
+    },
+    '100%': {
+      transform: 'scale(1.4, 1.4)',
+      opacity: 0,
+    },
+  },
+});
+
 export default function ToggleVideoButton() {
-  const { isChatWindowOpen, setIsChatWindowOpen } = useChatContext();
+  const classes = useStyles();
+  const [shouldAnimate, setShouldAnimate] = useState(false);
+  const { isChatWindowOpen, setIsChatWindowOpen, conversation, hasUnreadMessages } = useChatContext();
 
   const toggleChatWindow = () => {
     setIsChatWindowOpen(!isChatWindowOpen);
   };
 
+  useEffect(() => {
+    if (shouldAnimate) {
+      setTimeout(() => setShouldAnimate(false), ANIMATION_DURATION);
+    }
+  }, [shouldAnimate]);
+
+  useEffect(() => {
+    if (conversation && !isChatWindowOpen) {
+      const handleNewMessage = () => setShouldAnimate(true);
+      conversation.on('messageAdded', handleNewMessage);
+      return () => {
+        conversation.off('messageAdded', handleNewMessage);
+      };
+    }
+  }, [conversation, isChatWindowOpen]);
+
   return (
-    <Button onClick={toggleChatWindow} startIcon={<ChatIcon />}>
+    <Button
+      onClick={toggleChatWindow}
+      disabled={!conversation}
+      startIcon={
+        <div className={classes.iconContainer}>
+          <ChatIcon />
+          <div className={clsx(classes.ring, { [classes.animateRing]: shouldAnimate })} />
+          <div className={clsx(classes.circle, { [classes.hasUnreadMessages]: hasUnreadMessages })} />
+        </div>
+      }
+    >
       Chat
     </Button>
   );

--- a/src/components/Buttons/ToggleChatButton/ToggleChatButton.tsx
+++ b/src/components/Buttons/ToggleChatButton/ToggleChatButton.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles({
     opacity: 1,
   },
   ring: {
-    border: '3px solid #62bd19',
+    border: '3px solid #5BB75B',
     borderRadius: '30px',
     height: '14px',
     width: '14px',


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-3733](https://issues.corp.twilio.com/browse/VIDEO-3733)

### Description

This PR adds a notification to the Chat button in the menu, to let the user know when there are unread messages in the chat window. It also displays an animated 'blip' when each new message is received. When the user opens the chat window, the notification is cleared. The notification is not shown when new messages are received while the chat window is opened.

Here's a gif of three messages being received while the chat window is closed. Then, the chat button is clicked to open the chat window which clears the notification:

![chat](https://user-images.githubusercontent.com/12685223/110864262-17ff5900-827f-11eb-94e4-182a24627501.gif)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary