### PR TITLE
Video 4525 loading screen

### DIFF
--- a/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.test.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import DeviceSelectionScreen from './DeviceSelectionScreen';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import { shallow } from 'enzyme';
 import { Steps } from '../PreJoinScreens';
 import { useAppState } from '../../../state';
@@ -35,8 +36,8 @@ describe('the DeviceSelectionScreen component', () => {
 
     const wrapper = shallow(<DeviceSelectionScreen name="test name" roomName="test room name" setStep={() => {}} />);
 
-    it('should disable the Join Now button', () => {
-      expect(wrapper.find({ children: 'Join Now' }).prop('disabled')).toBe(true);
+    it('should show the loading screen', () => {
+      expect(wrapper.find(CircularProgress).prop('variant')).toBe('indeterminate');
     });
 
     it('should disable the desktop and mobile toggle video buttons', () => {
@@ -79,8 +80,8 @@ describe('the DeviceSelectionScreen component', () => {
     mockUseAppState.mockImplementationOnce(() => ({ getToken: mockGetToken, isFetching: true }));
     const wrapper = shallow(<DeviceSelectionScreen name="test name" roomName="test room name" setStep={() => {}} />);
 
-    it('should disable the Join Now button', () => {
-      expect(wrapper.find({ children: 'Join Now' }).prop('disabled')).toBe(true);
+    it('should show the loading screen', () => {
+      expect(wrapper.find(CircularProgress).prop('variant')).toBe('indeterminate');
     });
 
     it('should disable the desktop and mobile toggle video buttons', () => {

--- a/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.test.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.test.tsx
@@ -37,7 +37,7 @@ describe('the DeviceSelectionScreen component', () => {
     const wrapper = shallow(<DeviceSelectionScreen name="test name" roomName="test room name" setStep={() => {}} />);
 
     it('should show the loading screen', () => {
-      expect(wrapper.find(CircularProgress).prop('variant')).toBe('indeterminate');
+      expect(wrapper.find(CircularProgress).exists()).toBe(true);
     });
 
     it('should disable the desktop and mobile toggle video buttons', () => {
@@ -81,7 +81,7 @@ describe('the DeviceSelectionScreen component', () => {
     const wrapper = shallow(<DeviceSelectionScreen name="test name" roomName="test room name" setStep={() => {}} />);
 
     it('should show the loading screen', () => {
-      expect(wrapper.find(CircularProgress).prop('variant')).toBe('indeterminate');
+      expect(wrapper.find(CircularProgress).exists()).toBe(true);
     });
 
     it('should disable the desktop and mobile toggle video buttons', () => {

--- a/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { makeStyles, Typography, Grid, Button, Theme, Hidden } from '@material-ui/core';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import LocalVideoPreview from './LocalVideoPreview/LocalVideoPreview';
 import SettingsMenu from './SettingsMenu/SettingsMenu';
 import { Steps } from '../PreJoinScreens';
@@ -70,6 +71,21 @@ export default function DeviceSelectionScreen({ name, roomName, setStep }: Devic
       chatConnect(token);
     });
   };
+
+  if (isFetching || isConnecting) {
+    return (
+      <Grid container justify="center" spacing={2} alignItems="center" direction="column" style={{ height: '100%' }}>
+        <Grid item>
+          <CircularProgress variant="indeterminate" />
+        </Grid>
+        <Grid item>
+          <Typography variant="body2" style={{ fontWeight: 'bold', fontSize: '16px' }}>
+            Joining Meeting
+          </Typography>
+        </Grid>
+      </Grid>
+    );
+  }
 
   return (
     <>

--- a/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -74,15 +74,15 @@ export default function DeviceSelectionScreen({ name, roomName, setStep }: Devic
 
   if (isFetching || isConnecting) {
     return (
-      <Grid container justify="center" spacing={2} alignItems="center" direction="column" style={{ height: '100%' }}>
-        <Grid item>
+      <Grid container justify="center" alignItems="center" direction="column" style={{ height: '100%' }}>
+        <div>
           <CircularProgress variant="indeterminate" />
-        </Grid>
-        <Grid item>
+        </div>
+        <div>
           <Typography variant="body2" style={{ fontWeight: 'bold', fontSize: '16px' }}>
             Joining Meeting
           </Typography>
-        </Grid>
+        </div>
       </Grid>
     );
   }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-4525](https://issues.corp.twilio.com/browse/VIDEO-4525)

### Description

This PR adds a loading spinner while a participant is connecting to a room as it takes a second or two longer to join due to the addition of the new conversations feature. 

**Note**, because this spinner shows if either `isFetching` or `isConnecting` is true, the screen with the `Join Now` button is replaced by the loading screen. Therefore, I had to remove the following test from `describe('when connecting a room', () => {...})` and `describe('when fetching a token', () => {...})`:

` it('should disable the Join Now button', () => {...}`

Please let me know if I should have handled this differently!

**web:**
![4525](https://user-images.githubusercontent.com/77076398/111699481-95dadb80-880e-11eb-9c19-03c6e3dee480.gif)


**mobile:**
![4525-mobile](https://user-images.githubusercontent.com/77076398/111699503-9bd0bc80-880e-11eb-9b67-2ecf2f532fbf.gif)


## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary