### PR TITLE
Update MessageList component to change how messages are grouped

### DIFF
--- a/src/components/ChatWindow/MessageList/MessageList.test.tsx
+++ b/src/components/ChatWindow/MessageList/MessageList.test.tsx
@@ -6,54 +6,52 @@ jest.mock('../../../hooks/useVideoContext/useVideoContext', () => () => ({
   room: { localParticipant: { identity: 'olivia' } },
 }));
 
-const arbitraryDate = new Date(1614635301000);
-
 const messages: any = [
   {
     author: 'olivia',
-    dateCreated: arbitraryDate,
+    dateCreated: new Date(1614635301000),
     body: 'This is a message',
     sid: 'IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
     type: 'text',
   },
   {
     author: 'tim',
-    dateCreated: arbitraryDate,
+    dateCreated: new Date(1614635302000),
     body: 'Hi Olivia!',
     sid: 'IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX2',
     type: 'text',
   },
   {
     author: 'tim',
-    dateCreated: arbitraryDate,
+    dateCreated: new Date(1614635303000),
     body: 'That is pretty rad double line message! How did you do that?',
     sid: 'IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX3',
     type: 'text',
   },
   {
     author: 'tim',
-    dateCreated: arbitraryDate,
+    dateCreated: new Date(1614635383000),
     body: '😉',
     sid: 'IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX4',
     type: 'text',
   },
   {
     author: 'olivia',
-    dateCreated: new Date(1614635361000),
+    dateCreated: new Date(1614635389000),
     body: 'Magic',
     sid: 'IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX5',
     type: 'text',
   },
   {
     author: 'olivia',
-    dateCreated: new Date(1614635361000),
+    dateCreated: new Date(1614635410000),
     body: 'lots of magic',
     sid: 'IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX6',
     type: 'text',
   },
   {
     author: 'tim',
-    dateCreated: new Date(1614635361000),
+    dateCreated: new Date(1614635425000),
     body: 'look at this app: github.com/twilio/twilio-video-app-react. Neat huh?',
     sid: 'IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX7',
     type: 'text',

--- a/src/components/ChatWindow/MessageList/MessageList.tsx
+++ b/src/components/ChatWindow/MessageList/MessageList.tsx
@@ -28,11 +28,19 @@ export default function MessageList({ messages }: MessageListProps) {
         const time = message.dateCreated
           .toLocaleTimeString('en-us', { hour: 'numeric', minute: 'numeric' })
           .toLowerCase();
+
+        const previousTime = messages[idx - 1]?.dateCreated
+          .toLocaleTimeString('en-us', { hour: 'numeric', minute: 'numeric' })
+          .toLowerCase();
+
+        // Display the MessageInfo component when the author or formatted timestamp differs from the previous message
+        const shouldDisplayMessageInfo = time !== previousTime || message.author !== messages[idx - 1]?.author;
+
         const isLocalParticipant = localParticipant.identity === message.author;
 
         return (
           <React.Fragment key={message.sid}>
-            {messages[idx - 1]?.author !== message.author && (
+            {shouldDisplayMessageInfo && (
               <MessageInfo author={message.author} isLocalParticipant={isLocalParticipant} dateCreated={time} />
             )}
             {message.type === 'text' && <TextMessage body={message.body} isLocalParticipant={isLocalParticipant} />}

--- a/src/components/ChatWindow/MessageList/MessageList.tsx
+++ b/src/components/ChatWindow/MessageList/MessageList.tsx
@@ -17,6 +17,9 @@ const useStyles = makeStyles({
   },
 });
 
+const getFormattedTime = (message?: Message) =>
+  message?.dateCreated.toLocaleTimeString('en-us', { hour: 'numeric', minute: 'numeric' }).toLowerCase();
+
 export default function MessageList({ messages }: MessageListProps) {
   const classes = useStyles();
   const { room } = useVideoContext();
@@ -25,13 +28,8 @@ export default function MessageList({ messages }: MessageListProps) {
   return (
     <div className={classes.messageListContainer}>
       {messages.map((message, idx) => {
-        const time = message.dateCreated
-          .toLocaleTimeString('en-us', { hour: 'numeric', minute: 'numeric' })
-          .toLowerCase();
-
-        const previousTime = messages[idx - 1]?.dateCreated
-          .toLocaleTimeString('en-us', { hour: 'numeric', minute: 'numeric' })
-          .toLowerCase();
+        const time = getFormattedTime(message)!;
+        const previousTime = getFormattedTime(messages[idx - 1]);
 
         // Display the MessageInfo component when the author or formatted timestamp differs from the previous message
         const shouldDisplayMessageInfo = time !== previousTime || message.author !== messages[idx - 1]?.author;

--- a/src/components/ChatWindow/MessageList/__snapshots__/MessageList.test.tsx.snap
+++ b/src/components/ChatWindow/MessageList/__snapshots__/MessageList.test.tsx.snap
@@ -52,6 +52,16 @@ exports[`the messageList component should render correctly 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="makeStyles-messageInfoContainer-2"
+    >
+      <div>
+        tim
+      </div>
+      <div>
+        9:49 pm
+      </div>
+    </div>
     <div>
       <div
         class="makeStyles-messageContainer-3"
@@ -80,6 +90,16 @@ exports[`the messageList component should render correctly 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="makeStyles-messageInfoContainer-2"
+    >
+      <div>
+        olivia (You)
+      </div>
+      <div>
+        9:50 pm
+      </div>
+    </div>
     <div>
       <div
         class="makeStyles-messageContainer-3 makeStyles-isLocalParticipant-4"
@@ -96,7 +116,7 @@ exports[`the messageList component should render correctly 1`] = `
         tim
       </div>
       <div>
-        9:49 pm
+        9:50 pm
       </div>
     </div>
     <div>


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR changes how `MessageInfo` components are displayed in the `MessageList` component. Instead of displaying a `MessageInfo` component whenever a message has a new author, `MessageInfo` components are now displayed when a message has a new author or formatted timestamp. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary