### PR TITLE
Video 4739 add track switch off mode to connection options

### DIFF
--- a/src/utils/useConnectionOptions/useConnectionOptions.test.tsx
+++ b/src/utils/useConnectionOptions/useConnectionOptions.test.tsx
@@ -67,6 +67,7 @@ describe('the useConnectionOptions function', () => {
               width: 1280,
             },
           },
+          trackSwitchOffMode: 'detected',
         },
       },
       dominantSpeaker: true,

--- a/src/utils/useConnectionOptions/useConnectionOptions.ts
+++ b/src/utils/useConnectionOptions/useConnectionOptions.ts
@@ -23,6 +23,7 @@ export default function useConnectionOptions() {
           high: getResolution(settings.renderDimensionHigh),
         },
         maxTracks: Number(settings.maxTracks),
+        trackSwitchOffMode: settings.trackSwitchOffMode,
       },
     },
     dominantSpeaker: true,


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-4739](https://issues.corp.twilio.com/browse/VIDEO-4739)

### Description

This PR fixes the bug addressed in #474.

This PR adds the key-value pair `trackSwitchOffMode: settings.trackSwitchOffMode` to the `connectionOptions` object in the `useConnectionOptions` hook as it was previously missing.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] ~Added~ Updated unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary