### PR TITLE
Video 4893 show network for main participant

### DIFF
--- a/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: '0.3em',
     },
     marginRight: '0.4em',
+    alignItems: 'center',
   },
   infoContainer: {
     position: 'absolute',

--- a/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -38,8 +38,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%',
   },
   networkQualityIndicator: {
-    marginLeft: '5px',
-    paddingBottom: '3px',
+    marginLeft: '0.4em',
+    padding: '0.9em',
   },
   reconnectingContainer: {
     position: 'absolute',

--- a/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -25,21 +25,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     background: 'rgba(0, 0, 0, 0.5)',
     color: 'white',
     padding: '0.1em 0.3em 0.1em 0',
-    fontSize: '1.2em',
     display: 'inline-flex',
     '& svg': {
       marginLeft: '0.3em',
     },
+    marginRight: '0.4em',
   },
   infoContainer: {
     position: 'absolute',
     zIndex: 2,
     height: '100%',
     width: '100%',
-  },
-  networkQualityIndicator: {
-    marginLeft: '0.4em',
-    padding: '0.9em',
   },
   reconnectingContainer: {
     position: 'absolute',
@@ -121,7 +117,7 @@ export default function MainParticipantInfo({ participant, children }: MainParti
               {screenSharePublication && ' - Screen'}
             </Typography>
           </div>
-          <NetworkQualityLevel participant={localParticipant} className={classes.networkQualityIndicator} />
+          <NetworkQualityLevel participant={localParticipant} />
         </div>
       </div>
       {(!isVideoEnabled || isVideoSwitchedOff) && (

--- a/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -13,6 +13,7 @@ import useTrack from '../../hooks/useTrack/useTrack';
 import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
 import useParticipantIsReconnecting from '../../hooks/useParticipantIsReconnecting/useParticipantIsReconnecting';
 import AudioLevelIndicator from '../AudioLevelIndicator/AudioLevelIndicator';
+import NetworkQualityLevel from '../NetworkQualityLevel/NetworkQualityLevel';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -35,6 +36,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     zIndex: 2,
     height: '100%',
     width: '100%',
+  },
+  networkQualityIndicator: {
+    marginLeft: '5px',
+    paddingBottom: '3px',
   },
   reconnectingContainer: {
     position: 'absolute',
@@ -107,13 +112,16 @@ export default function MainParticipantInfo({ participant, children }: MainParti
       })}
     >
       <div className={classes.infoContainer}>
-        <div className={classes.identity}>
-          <AudioLevelIndicator audioTrack={audioTrack} />
-          <Typography variant="body1" color="inherit">
-            {participant.identity}
-            {isLocal && ' (You)'}
-            {screenSharePublication && ' - Screen'}
-          </Typography>
+        <div style={{ display: 'flex' }}>
+          <div className={classes.identity}>
+            <AudioLevelIndicator audioTrack={audioTrack} />
+            <Typography variant="body1" color="inherit">
+              {participant.identity}
+              {isLocal && ' (You)'}
+              {screenSharePublication && ' - Screen'}
+            </Typography>
+          </div>
+          <NetworkQualityLevel participant={localParticipant} className={classes.networkQualityIndicator} />
         </div>
       </div>
       {(!isVideoEnabled || isVideoSwitchedOff) && (

--- a/src/components/NetworkQualityLevel/NetworkQualityLevel.tsx
+++ b/src/components/NetworkQualityLevel/NetworkQualityLevel.tsx
@@ -1,39 +1,58 @@
 import React from 'react';
-import { styled } from '@material-ui/core/styles';
+import clsx from 'clsx';
+import { makeStyles } from '@material-ui/core/styles';
 import { Participant } from 'twilio-video';
 import useParticipantNetworkQualityLevel from '../../hooks/useParticipantNetworkQualityLevel/useParticipantNetworkQualityLevel';
 
-const Container = styled('div')({
-  display: 'flex',
-  alignItems: 'flex-end',
-  '& div': {
-    width: '2px',
-    marginRight: '1px',
-    '&:not(:last-child)': {
-      borderRight: 'none',
+const useStyles = makeStyles({
+  outerContainer: {
+    width: '28px',
+    height: '28px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'rgba(0, 0, 0, 0.5)',
+  },
+  innerContainer: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    '& div': {
+      width: '2px',
+      marginRight: '1px',
+      '&:not(:last-child)': {
+        borderRight: 'none',
+      },
     },
   },
 });
 
+interface NetworkQualityLevelProps {
+  participant: Participant;
+  className?: string;
+}
+
 const STEP = 3;
 const BARS_ARRAY = [0, 1, 2, 3, 4];
 
-export default function NetworkQualityLevel({ participant }: { participant: Participant }) {
+export default function NetworkQualityLevel({ participant, className }: NetworkQualityLevelProps) {
+  const classes = useStyles();
   const networkQualityLevel = useParticipantNetworkQualityLevel(participant);
 
   if (networkQualityLevel === null) return null;
 
   return (
-    <Container>
-      {BARS_ARRAY.map(level => (
-        <div
-          key={level}
-          style={{
-            height: `${STEP * (level + 1)}px`,
-            background: networkQualityLevel > level ? 'white' : 'rgba(255, 255, 255, 0.2)',
-          }}
-        />
-      ))}
-    </Container>
+    <div className={clsx(classes.outerContainer, className)}>
+      <div className={classes.innerContainer}>
+        {BARS_ARRAY.map(level => (
+          <div
+            key={level}
+            style={{
+              height: `${STEP * (level + 1)}px`,
+              background: networkQualityLevel > level ? 'white' : 'rgba(255, 255, 255, 0.2)',
+            }}
+          />
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/components/NetworkQualityLevel/NetworkQualityLevel.tsx
+++ b/src/components/NetworkQualityLevel/NetworkQualityLevel.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import clsx from 'clsx';
 import { makeStyles } from '@material-ui/core/styles';
 import { Participant } from 'twilio-video';
 import useParticipantNetworkQualityLevel from '../../hooks/useParticipantNetworkQualityLevel/useParticipantNetworkQualityLevel';
 
 const useStyles = makeStyles({
   outerContainer: {
-    width: '28px',
-    height: '28px',
+    width: '2em',
+    height: '2em',
+    padding: '0.9em',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -26,22 +26,17 @@ const useStyles = makeStyles({
   },
 });
 
-interface NetworkQualityLevelProps {
-  participant: Participant;
-  className?: string;
-}
-
 const STEP = 3;
 const BARS_ARRAY = [0, 1, 2, 3, 4];
 
-export default function NetworkQualityLevel({ participant, className }: NetworkQualityLevelProps) {
+export default function NetworkQualityLevel({ participant }: { participant: Participant }) {
   const classes = useStyles();
   const networkQualityLevel = useParticipantNetworkQualityLevel(participant);
 
   if (networkQualityLevel === null) return null;
 
   return (
-    <div className={clsx(classes.outerContainer, className)}>
+    <div className={classes.outerContainer}>
       <div className={classes.innerContainer}>
         {BARS_ARRAY.map(level => (
           <div

--- a/src/components/NetworkQualityLevel/__snapshots__/NetworkQualityLevel.test.tsx.snap
+++ b/src/components/NetworkQualityLevel/__snapshots__/NetworkQualityLevel.test.tsx.snap
@@ -2,141 +2,153 @@
 
 exports[`the NetworkQualityLevel component should render correctly for level 0 1`] = `
 <div
-  className="div-root-1"
+  className="makeStyles-outerContainer-1"
 >
   <div
-    style={
-      Object {
-        "background": "rgba(255, 255, 255, 0.2)",
-        "height": "3px",
+    className="makeStyles-innerContainer-2"
+  >
+    <div
+      style={
+        Object {
+          "background": "rgba(255, 255, 255, 0.2)",
+          "height": "3px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "rgba(255, 255, 255, 0.2)",
-        "height": "6px",
+    />
+    <div
+      style={
+        Object {
+          "background": "rgba(255, 255, 255, 0.2)",
+          "height": "6px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "rgba(255, 255, 255, 0.2)",
-        "height": "9px",
+    />
+    <div
+      style={
+        Object {
+          "background": "rgba(255, 255, 255, 0.2)",
+          "height": "9px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "rgba(255, 255, 255, 0.2)",
-        "height": "12px",
+    />
+    <div
+      style={
+        Object {
+          "background": "rgba(255, 255, 255, 0.2)",
+          "height": "12px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "rgba(255, 255, 255, 0.2)",
-        "height": "15px",
+    />
+    <div
+      style={
+        Object {
+          "background": "rgba(255, 255, 255, 0.2)",
+          "height": "15px",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;
 
 exports[`the NetworkQualityLevel component should render correctly for level 3 1`] = `
 <div
-  className="div-root-1"
+  className="makeStyles-outerContainer-1"
 >
   <div
-    style={
-      Object {
-        "background": "white",
-        "height": "3px",
+    className="makeStyles-innerContainer-2"
+  >
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "3px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "white",
-        "height": "6px",
+    />
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "6px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "white",
-        "height": "9px",
+    />
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "9px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "rgba(255, 255, 255, 0.2)",
-        "height": "12px",
+    />
+    <div
+      style={
+        Object {
+          "background": "rgba(255, 255, 255, 0.2)",
+          "height": "12px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "rgba(255, 255, 255, 0.2)",
-        "height": "15px",
+    />
+    <div
+      style={
+        Object {
+          "background": "rgba(255, 255, 255, 0.2)",
+          "height": "15px",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;
 
 exports[`the NetworkQualityLevel component should render correctly for level 5 1`] = `
 <div
-  className="div-root-1"
+  className="makeStyles-outerContainer-1"
 >
   <div
-    style={
-      Object {
-        "background": "white",
-        "height": "3px",
+    className="makeStyles-innerContainer-2"
+  >
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "3px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "white",
-        "height": "6px",
+    />
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "6px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "white",
-        "height": "9px",
+    />
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "9px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "white",
-        "height": "12px",
+    />
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "12px",
+        }
       }
-    }
-  />
-  <div
-    style={
-      Object {
-        "background": "white",
-        "height": "15px",
+    />
+    <div
+      style={
+        Object {
+          "background": "white",
+          "height": "15px",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;

--- a/src/components/ParticipantInfo/ParticipantInfo.tsx
+++ b/src/components/ParticipantInfo/ParticipantInfo.tsx
@@ -112,14 +112,6 @@ const useStyles = makeStyles((theme: Theme) =>
       bottom: 0,
       left: 0,
     },
-    networkQualityContainer: {
-      width: '28px',
-      height: '28px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      background: 'rgba(0, 0, 0, 0.5)',
-    },
     typeography: {
       color: 'white',
       [theme.breakpoints.down('sm')]: {
@@ -178,9 +170,7 @@ export default function ParticipantInfo({
       data-cy-participant={participant.identity}
     >
       <div className={classes.infoContainer}>
-        <div className={classes.networkQualityContainer}>
-          <NetworkQualityLevel participant={participant} />
-        </div>
+        <NetworkQualityLevel participant={participant} />
         <div className={classes.infoRowBottom}>
           {isScreenShareEnabled && (
             <span className={classes.screenShareIconContainer}>


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-4893](https://issues.corp.twilio.com/browse/VIDEO-4893)

### Description

This PR adds the network quality indicator to the main participant. This is the same network quality indicator that is used by the `<ParticipantInfo />` component. We decided to move the styling to the `<NetworkQualityLevel />` in order to remove the empty boxes from the participant thumbnails in P2P rooms. 

GitHub issue: #490 

Screenshots:
**Main participant === localParticipant:**
![Screen Shot 2021-04-20 at 7 07 48 PM](https://user-images.githubusercontent.com/77076398/115476562-1b87e780-a210-11eb-8426-88f58fe94774.png)

**Main participant !== localParticipant:**
![Screen Shot 2021-04-20 at 7 07 14 PM](https://user-images.githubusercontent.com/77076398/115476592-2d698a80-a210-11eb-81c7-c8b1f874561c.png)


## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary