### PR TITLE
add empty object as constraints parameter for restart method

### DIFF
--- a/src/components/VideoProvider/useRestartAudioTrackOnDeviceChange/useRestartAudioTrackOnDeviceChange.test.tsx
+++ b/src/components/VideoProvider/useRestartAudioTrackOnDeviceChange/useRestartAudioTrackOnDeviceChange.test.tsx
@@ -30,7 +30,7 @@ describe('the useHandleTrackPublicationFailed hook', () => {
     // call handleDeviceChange function:
     mockAddEventListener.mock.calls[0][1]();
 
-    expect(localTrack[0].restart).toHaveBeenCalled();
+    expect(localTrack[0].restart).toHaveBeenCalledWith({});
   });
 
   it('should remove the event handler when component unmounts', () => {

--- a/src/components/VideoProvider/useRestartAudioTrackOnDeviceChange/useRestartAudioTrackOnDeviceChange.ts
+++ b/src/components/VideoProvider/useRestartAudioTrackOnDeviceChange/useRestartAudioTrackOnDeviceChange.ts
@@ -16,7 +16,7 @@ export default function useRestartAudioTrackOnDeviceChange(localTracks: (LocalAu
   useEffect(() => {
     const handleDeviceChange = () => {
       if (audioTrack?.mediaStreamTrack.readyState === 'ended') {
-        audioTrack.restart();
+        audioTrack.restart({});
       }
     };
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR addresses a follow-up bug to GitHub issue #462. In Firefox, when a user is connected to a room and uses an external microphone (or headphones with a built-in microphone), and then disconnects that mic, the other participants can no longer hear the user despite being unmuted. We fixed this by passing an empty object `{}` to `audioTrack.restart()` in the `useRestartAudioTrackOnDeviceChange` hook, which will use the default `MediaTrackConstraints` as a result.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary