### PR TITLE
Remove usedevices from uselocaltracks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17945,9 +17945,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -21191,9 +21191,9 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -25233,9 +25233,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -25970,8 +25970,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/src/__mocks__/twilio-video.ts
+++ b/src/__mocks__/twilio-video.ts
@@ -14,6 +14,7 @@ const mockRoom = new MockRoom();
 class MockTrack extends EventEmitter {
   kind = '';
   stop = jest.fn();
+  mediaStreamTrack = { getCapabilities: () => ({ deviceId: 'mockDeviceId' }) };
 
   constructor(kind: string) {
     super();
@@ -23,8 +24,11 @@ class MockTrack extends EventEmitter {
 
 const twilioVideo = {
   connect: jest.fn(() => Promise.resolve(mockRoom)),
-  createLocalTracks: jest.fn(() => Promise.resolve([new MockTrack('video'), new MockTrack('audio')])),
-  createLocalVideoTrack: jest.fn(() => Promise.resolve(new MockTrack('video'))),
+  createLocalTracks: jest.fn(
+    // Here we use setTimeout so we can control when this function resolves with jest.runAllTimers()
+    () => new Promise(resolve => setTimeout(() => resolve([new MockTrack('video'), new MockTrack('audio')])))
+  ),
+  createLocalVideoTrack: jest.fn(() => new Promise(resolve => setTimeout(() => resolve(new MockTrack('video'))))),
 };
 
 export { mockRoom };

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -89,6 +89,8 @@ export default function useLocalTracks() {
         const newAudioTrack = tracks.find(track => track.kind === 'audio') as LocalAudioTrack;
         if (newVideoTrack) {
           setVideoTrack(newVideoTrack);
+          // Save the deviceId so it can be picked up by the VideoInputList component. This only matters
+          // in cases where the user's video is disabled.
           window.localStorage.setItem(
             SELECTED_VIDEO_INPUT_KEY,
             newVideoTrack.mediaStreamTrack.getCapabilities().deviceId ?? ''

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -1,13 +1,12 @@
 import { DEFAULT_VIDEO_CONSTRAINTS, SELECTED_AUDIO_INPUT_KEY, SELECTED_VIDEO_INPUT_KEY } from '../../../constants';
+import { getDeviceInfo } from '../../../utils';
 import { useCallback, useState } from 'react';
 import Video, { LocalVideoTrack, LocalAudioTrack, CreateLocalTrackOptions } from 'twilio-video';
-import useDevices from '../../../hooks/useDevices/useDevices';
 
 export default function useLocalTracks() {
   const [audioTrack, setAudioTrack] = useState<LocalAudioTrack>();
   const [videoTrack, setVideoTrack] = useState<LocalVideoTrack>();
   const [isAcquiringLocalTracks, setIsAcquiringLocalTracks] = useState(false);
-  const { audioInputDevices, videoInputDevices, hasAudioInputDevices, hasVideoInputDevices } = useDevices();
 
   const getLocalAudioTrack = useCallback((deviceId?: string) => {
     const options: CreateLocalTrackOptions = {};
@@ -22,8 +21,10 @@ export default function useLocalTracks() {
     });
   }, []);
 
-  const getLocalVideoTrack = useCallback(() => {
+  const getLocalVideoTrack = useCallback(async () => {
     const selectedVideoDeviceId = window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY);
+
+    const { videoInputDevices } = await getDeviceInfo();
 
     const hasSelectedVideoDevice = videoInputDevices.some(
       device => selectedVideoDeviceId && device.deviceId === selectedVideoDeviceId
@@ -39,7 +40,7 @@ export default function useLocalTracks() {
       setVideoTrack(newTrack);
       return newTrack;
     });
-  }, [videoInputDevices]);
+  }, []);
 
   const removeLocalAudioTrack = useCallback(() => {
     if (audioTrack) {
@@ -55,7 +56,9 @@ export default function useLocalTracks() {
     }
   }, [videoTrack]);
 
-  const getAudioAndVideoTracks = useCallback(() => {
+  const getAudioAndVideoTracks = useCallback(async () => {
+    const { audioInputDevices, videoInputDevices, hasAudioInputDevices, hasVideoInputDevices } = await getDeviceInfo();
+
     if (!hasAudioInputDevices && !hasVideoInputDevices) return Promise.resolve();
     if (isAcquiringLocalTracks || audioTrack || videoTrack) return Promise.resolve();
 
@@ -82,25 +85,21 @@ export default function useLocalTracks() {
 
     return Video.createLocalTracks(localTrackConstraints)
       .then(tracks => {
-        const newVideoTrack = tracks.find(track => track.kind === 'video');
-        const newAudioTrack = tracks.find(track => track.kind === 'audio');
+        const newVideoTrack = tracks.find(track => track.kind === 'video') as LocalVideoTrack;
+        const newAudioTrack = tracks.find(track => track.kind === 'audio') as LocalAudioTrack;
         if (newVideoTrack) {
-          setVideoTrack(newVideoTrack as LocalVideoTrack);
+          setVideoTrack(newVideoTrack);
+          window.localStorage.setItem(
+            SELECTED_VIDEO_INPUT_KEY,
+            newVideoTrack.mediaStreamTrack.getCapabilities().deviceId ?? ''
+          );
         }
         if (newAudioTrack) {
-          setAudioTrack(newAudioTrack as LocalAudioTrack);
+          setAudioTrack(newAudioTrack);
         }
       })
       .finally(() => setIsAcquiringLocalTracks(false));
-  }, [
-    hasAudioInputDevices,
-    hasVideoInputDevices,
-    audioTrack,
-    videoTrack,
-    audioInputDevices,
-    videoInputDevices,
-    isAcquiringLocalTracks,
-  ]);
+  }, [audioTrack, videoTrack, isAcquiringLocalTracks]);
 
   const localTracks = [audioTrack, videoTrack].filter(track => track !== undefined) as (
     | LocalAudioTrack

--- a/src/hooks/useDevices/useDevices.tsx
+++ b/src/hooks/useDevices/useDevices.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { getDeviceInfo } from '../../utils';
 
 // This returns the type of the value that is returned by a promise resolution
-type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
+type ThenArg<T> = T extends PromiseLike<infer U> ? U : never;
 
 export default function useDevices() {
   const [deviceInfo, setDeviceInfo] = useState<ThenArg<ReturnType<typeof getDeviceInfo>>>({

--- a/src/hooks/useDevices/useDevices.tsx
+++ b/src/hooks/useDevices/useDevices.tsx
@@ -1,10 +1,20 @@
 import { useState, useEffect } from 'react';
+import { getDeviceInfo } from '../../utils';
+
+// This returns the type of the value that is returned by a promise resolution
+type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
 
 export default function useDevices() {
-  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [deviceInfo, setDeviceInfo] = useState<ThenArg<ReturnType<typeof getDeviceInfo>>>({
+    audioInputDevices: [],
+    videoInputDevices: [],
+    audioOutputDevices: [],
+    hasAudioInputDevices: false,
+    hasVideoInputDevices: false,
+  });
 
   useEffect(() => {
-    const getDevices = () => navigator.mediaDevices.enumerateDevices().then(newDevices => setDevices(newDevices));
+    const getDevices = () => getDeviceInfo().then(devices => setDeviceInfo(devices));
     navigator.mediaDevices.addEventListener('devicechange', getDevices);
     getDevices();
 
@@ -13,11 +23,5 @@ export default function useDevices() {
     };
   }, []);
 
-  return {
-    audioInputDevices: devices.filter(device => device.kind === 'audioinput'),
-    videoInputDevices: devices.filter(device => device.kind === 'videoinput'),
-    audioOutputDevices: devices.filter(device => device.kind === 'audiooutput'),
-    hasAudioInputDevices: devices.filter(device => device.kind === 'audioinput').length > 0,
-    hasVideoInputDevices: devices.filter(device => device.kind === 'videoinput').length > 0,
-  };
+  return deviceInfo;
 }

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -84,7 +84,7 @@ describe('the getDeviceInfo function', () => {
     expect(result.hasAudioInputDevices).toBe(false);
   });
 
-  it('should return hasAudioInputDevices: false when there are no audio input devices', async () => {
+  it('should return hasVideoInputDevices: false when there are no video input devices', async () => {
     navigator.mediaDevices.enumerateDevices = () =>
       // @ts-ignore
       Promise.resolve([

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { removeUndefineds } from '.';
+import { getDeviceInfo, removeUndefineds } from '.';
 
 describe('the removeUndefineds function', () => {
   it('should recursively remove any object keys with a value of undefined', () => {
@@ -27,5 +27,71 @@ describe('the removeUndefineds function', () => {
     };
 
     expect(removeUndefineds(data)).toEqual(result);
+  });
+});
+
+describe('the getDeviceInfo function', () => {
+  // @ts-ignore
+  navigator.mediaDevices = {};
+
+  let mockDevices = [
+    { deviceId: 1, label: '1', kind: 'audioinput' },
+    { deviceId: 2, label: '2', kind: 'videoinput' },
+    { deviceId: 3, label: '3', kind: 'audiooutput' },
+  ];
+
+  it('should correctly return a list of audio input devices', async () => {
+    // @ts-ignore
+    navigator.mediaDevices.enumerateDevices = () => Promise.resolve(mockDevices);
+    const result = await getDeviceInfo();
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "audioInputDevices": Array [
+          Object {
+            "deviceId": 1,
+            "kind": "audioinput",
+            "label": "1",
+          },
+        ],
+        "audioOutputDevices": Array [
+          Object {
+            "deviceId": 3,
+            "kind": "audiooutput",
+            "label": "3",
+          },
+        ],
+        "hasAudioInputDevices": true,
+        "hasVideoInputDevices": true,
+        "videoInputDevices": Array [
+          Object {
+            "deviceId": 2,
+            "kind": "videoinput",
+            "label": "2",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return hasAudioInputDevices: false when there are no audio input devices', async () => {
+    navigator.mediaDevices.enumerateDevices = () =>
+      // @ts-ignore
+      Promise.resolve([
+        { deviceId: 2, label: '2', kind: 'videoinput' },
+        { deviceId: 3, label: '3', kind: 'audiooutput' },
+      ]);
+    const result = await getDeviceInfo();
+    expect(result.hasAudioInputDevices).toBe(false);
+  });
+
+  it('should return hasAudioInputDevices: false when there are no audio input devices', async () => {
+    navigator.mediaDevices.enumerateDevices = () =>
+      // @ts-ignore
+      Promise.resolve([
+        { deviceId: 1, label: '1', kind: 'audioinput' },
+        { deviceId: 3, label: '3', kind: 'audiooutput' },
+      ]);
+    const result = await getDeviceInfo();
+    expect(result.hasVideoInputDevices).toBe(false);
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,3 +22,15 @@ export function removeUndefineds<T>(obj: T): T {
 
   return target as T;
 }
+
+export async function getDeviceInfo() {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+
+  return {
+    audioInputDevices: devices.filter(device => device.kind === 'audioinput'),
+    videoInputDevices: devices.filter(device => device.kind === 'videoinput'),
+    audioOutputDevices: devices.filter(device => device.kind === 'audiooutput'),
+    hasAudioInputDevices: devices.some(device => device.kind === 'audioinput'),
+    hasVideoInputDevices: devices.some(device => device.kind === 'videoinput'),
+  };
+}


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This pull request removes the usage of the `useDevices` hook from the `useLocalTracks` hook. 

The values in the `useDevices` hook are not updated after a user grants permission to their microphone and camera. Because of this, the values returned by `useDevices` can be stale by the time they are used in the callbacks inside `useLocalTracks`. 

This issue is solved by calling `enumerateDevices` at the beginning  of the execution of the `useLocalTracks` callbacks. With this, the device information is never stale.

Resolves: #425

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary