### PR TITLE
Conditionally render recording rules button

### DIFF
--- a/src/components/MenuBar/Menu/Menu.test.tsx
+++ b/src/components/MenuBar/Menu/Menu.test.tsx
@@ -33,7 +33,11 @@ describe('the Menu component', () => {
 
   beforeAll(() => {
     mockUpdateRecordingRules = jest.fn(() => Promise.resolve());
-    mockUseAppState.mockImplementation(() => ({ isFetching: false, updateRecordingRules: mockUpdateRecordingRules }));
+    mockUseAppState.mockImplementation(() => ({
+      isFetching: false,
+      updateRecordingRules: mockUpdateRecordingRules,
+      roomType: 'group',
+    }));
     mockUseFlipCameraToggle.mockImplementation(() => ({
       flipCameraDisabled: false,
       flipCameraSupported: false,
@@ -67,6 +71,61 @@ describe('the Menu component', () => {
     describe('while recording is not in progress', () => {
       beforeAll(() => {
         mockUseIsRecording.mockImplementation(() => false);
+      });
+
+      it('should render the recording button in group rooms', () => {
+        mockUseAppState.mockImplementation(() => ({
+          isFetching: false,
+          updateRecordingRules: mockUpdateRecordingRules,
+          roomType: 'group',
+        }));
+        const { getByText } = render(<Menu />);
+        fireEvent.click(getByText('More'));
+        expect(getByText('Start Recording')).toBeTruthy();
+      });
+
+      it('should render the recording button in group-small rooms', () => {
+        mockUseAppState.mockImplementation(() => ({
+          isFetching: false,
+          updateRecordingRules: mockUpdateRecordingRules,
+          roomType: 'group-small',
+        }));
+        const { getByText } = render(<Menu />);
+        fireEvent.click(getByText('More'));
+        expect(getByText('Start Recording')).toBeTruthy();
+      });
+
+      it('should not render the recording button in go rooms', () => {
+        mockUseAppState.mockImplementation(() => ({
+          isFetching: false,
+          updateRecordingRules: mockUpdateRecordingRules,
+          roomType: 'go',
+        }));
+        const { getByText, queryByText } = render(<Menu />);
+        fireEvent.click(getByText('More'));
+        expect(queryByText('Start Recording')).toBeNull();
+      });
+
+      it('should not render the recording button in peer-to-peer rooms', () => {
+        mockUseAppState.mockImplementation(() => ({
+          isFetching: false,
+          updateRecordingRules: mockUpdateRecordingRules,
+          roomType: 'peer-to-peer',
+        }));
+        const { getByText, queryByText } = render(<Menu />);
+        fireEvent.click(getByText('More'));
+        expect(queryByText('Start Recording')).toBeNull();
+      });
+
+      it('should render the recording button when roomType is undefined', () => {
+        mockUseAppState.mockImplementation(() => ({
+          isFetching: false,
+          updateRecordingRules: mockUpdateRecordingRules,
+          roomType: undefined,
+        }));
+        const { getByText } = render(<Menu />);
+        fireEvent.click(getByText('More'));
+        expect(getByText('Start Recording')).toBeTruthy();
       });
 
       it('should display "Start Recording"', () => {

--- a/src/components/MenuBar/Menu/Menu.tsx
+++ b/src/components/MenuBar/Menu/Menu.tsx
@@ -29,7 +29,7 @@ export default function Menu(props: { buttonClassName?: string }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const { isFetching, updateRecordingRules } = useAppState();
+  const { isFetching, updateRecordingRules, roomType } = useAppState();
   const { room } = useVideoContext();
   const isRecording = useIsRecording();
 
@@ -66,21 +66,23 @@ export default function Menu(props: { buttonClassName?: string }) {
           horizontal: 'center',
         }}
       >
-        <MenuItem
-          disabled={isFetching}
-          onClick={() => {
-            setMenuOpen(false);
-            if (isRecording) {
-              updateRecordingRules(room!.sid, [{ type: 'exclude', all: true }]);
-            } else {
-              updateRecordingRules(room!.sid, [{ type: 'include', all: true }]);
-            }
-          }}
-          data-cy-recording-button
-        >
-          <IconContainer>{isRecording ? <StopRecordingIcon /> : <StartRecordingIcon />}</IconContainer>
-          <Typography variant="body1">{isRecording ? 'Stop' : 'Start'} Recording</Typography>
-        </MenuItem>
+        {roomType !== 'peer-to-peer' && roomType !== 'go' && (
+          <MenuItem
+            disabled={isFetching}
+            onClick={() => {
+              setMenuOpen(false);
+              if (isRecording) {
+                updateRecordingRules(room!.sid, [{ type: 'exclude', all: true }]);
+              } else {
+                updateRecordingRules(room!.sid, [{ type: 'include', all: true }]);
+              }
+            }}
+            data-cy-recording-button
+          >
+            <IconContainer>{isRecording ? <StopRecordingIcon /> : <StartRecordingIcon />}</IconContainer>
+            <Typography variant="body1">{isRecording ? 'Stop' : 'Start'} Recording</Typography>
+          </MenuItem>
+        )}
         {flipCameraSupported && (
           <MenuItem disabled={flipCameraDisabled} onClick={toggleFacingMode}>
             <IconContainer>

--- a/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.test.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.test.tsx
@@ -13,7 +13,7 @@ const mockUseVideoContext = useVideoContext as jest.Mock<any>;
 
 const mockConnect = jest.fn();
 const mockChatConnect = jest.fn(() => Promise.resolve());
-const mockGetToken = jest.fn(() => Promise.resolve('mockToken'));
+const mockGetToken = jest.fn(() => Promise.resolve({ token: 'mockToken' }));
 
 jest.mock('../../../hooks/useChatContext/useChatContext', () => () => ({ connect: mockChatConnect }));
 jest.mock('../../../hooks/useVideoContext/useVideoContext');

--- a/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -66,7 +66,7 @@ export default function DeviceSelectionScreen({ name, roomName, setStep }: Devic
   const disableButtons = isFetching || isAcquiringLocalTracks || isConnecting;
 
   const handleJoin = () => {
-    getToken(name, roomName).then(token => {
+    getToken(name, roomName).then(({ token }) => {
       videoConnect(token);
       process.env.REACT_APP_DISABLE_TWILIO_CONVERSATIONS !== 'true' && chatConnect(token);
     });

--- a/src/state/index.test.tsx
+++ b/src/state/index.test.tsx
@@ -48,7 +48,7 @@ describe('the useAppState hook', () => {
       token = await result.current.getToken('testname', 'testroom');
     });
 
-    expect(token).toBe('mockVideoToken');
+    expect(token).toEqual({ token: 'mockVideoToken' });
 
     expect(window.fetch).toHaveBeenCalledWith('http://test.com/api/token', {
       headers: { 'content-type': 'application/json' },

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -114,7 +114,6 @@ export default function AppStateProvider(props: React.PropsWithChildren<{}>) {
     return contextValue
       .getToken(name, room)
       .then(res => {
-        console.log(res, res.room_type);
         setRoomType(res.room_type);
         setIsFetching(false);
         return res;

--- a/src/state/useFirebaseAuth/useFirebaseAuth.ts
+++ b/src/state/useFirebaseAuth/useFirebaseAuth.ts
@@ -32,9 +32,7 @@ export default function useFirebaseAuth() {
           room_name,
           create_conversation: process.env.REACT_APP_DISABLE_TWILIO_CONVERSATIONS !== 'true',
         }),
-      })
-        .then(res => res.json())
-        .then(res => res.token as string);
+      }).then(res => res.json());
     },
     [user]
   );

--- a/src/state/usePasscodeAuth/usePasscodeAuth.test.tsx
+++ b/src/state/usePasscodeAuth/usePasscodeAuth.test.tsx
@@ -178,7 +178,7 @@ describe('the usePasscodeAuth hook', () => {
       await act(async () => {
         token = await result.current.getToken('test-name', 'test-room');
       });
-      expect(token).toBe('mockVideoToken');
+      expect(token).toEqual({ token: 'mockVideoToken' });
     });
 
     it('should return a useful error message from the serverless function', async () => {

--- a/src/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -1,4 +1,3 @@
-import { RoomType } from '../../types';
 import { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -61,7 +60,6 @@ export default function usePasscodeAuth() {
 
   const [user, setUser] = useState<{ displayName: undefined; photoURL: undefined; passcode: string } | null>(null);
   const [isAuthReady, setIsAuthReady] = useState(false);
-  const [roomType, setRoomType] = useState<RoomType>();
 
   const getToken = useCallback(
     (name: string, room: string) => {
@@ -74,11 +72,7 @@ export default function usePasscodeAuth() {
           const errorMessage = getErrorMessage(json.error?.message || res.statusText);
           throw Error(errorMessage);
         })
-        .then(res => res.json())
-        .then(res => {
-          setRoomType(res.room_type);
-          return res.token as string;
-        });
+        .then(res => res.json());
     },
     [user]
   );
@@ -142,5 +136,5 @@ export default function usePasscodeAuth() {
     return Promise.resolve();
   }, []);
 
-  return { user, isAuthReady, getToken, signIn, signOut, roomType, updateRecordingRules };
+  return { user, isAuthReady, getToken, signIn, signOut, updateRecordingRules };
 }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR adds logic so that the recording start/stop button isn't rendered when the room type is peer-to-peer or go. 

Additionally, some of the token request logic in src/state was modified so that the roomType is saved no matter which authentication scheme is used. 

If the roomType is ever unknown (a developer using their own server that isn't properly set up), then the recording button will be rendered. If the room type doesn't allow recording, the user will see a useful error message:

![image](https://user-images.githubusercontent.com/12685223/117489941-6cdfe880-af2b-11eb-8d95-a7bd61fdff28.png)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary