### PR TITLE
Fix firefox styling of textarea element

### DIFF
--- a/src/components/ChatWindow/ChatInput/ChatInput.test.tsx
+++ b/src/components/ChatWindow/ChatInput/ChatInput.test.tsx
@@ -114,6 +114,30 @@ describe('the ChatInput component', () => {
     expect(mockHandleSendMessage).not.toHaveBeenCalled();
   });
 
+  it('should add the "isTextareaFocused" class to the parent of TextareaAutosize when the focus event is fired, and remove it when the blur event is fired', () => {
+    const wrapper = mount(
+      <ChatInput conversation={{ sendMessage: mockHandleSendMessage } as any} isChatWindowOpen={true} />
+    );
+
+    wrapper.find(TextareaAutosize).simulate('focus');
+
+    expect(
+      wrapper
+        .find(TextareaAutosize)
+        .parent()
+        .prop('className')
+    ).toContain('isTextareaFocused');
+
+    wrapper.find(TextareaAutosize).simulate('blur');
+
+    expect(
+      wrapper
+        .find(TextareaAutosize)
+        .parent()
+        .prop('className')
+    ).not.toContain('isTextareaFocused');
+  });
+
   it('should disable the file input button and display a loading spinner while sending a file', done => {
     const wrapper = shallow(
       <ChatInput conversation={{ sendMessage: mockHandleSendMessage } as any} isChatWindowOpen={true} />

--- a/src/components/ChatWindow/ChatInput/ChatInput.tsx
+++ b/src/components/ChatWindow/ChatInput/ChatInput.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Button, CircularProgress, Grid, makeStyles } from '@material-ui/core';
+import clsx from 'clsx';
 import { Conversation } from '@twilio/conversations/lib/conversation';
 import FileAttachmentIcon from '../../../icons/FileAttachmentIcon';
 import { isMobile } from '../../../utils';
@@ -7,20 +8,19 @@ import SendMessageIcon from '../../../icons/SendMessageIcon';
 import Snackbar from '../../Snackbar/Snackbar';
 import TextareaAutosize from '@material-ui/core/TextareaAutosize';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   chatInputContainer: {
     borderTop: '1px solid #e4e7e9',
     borderBottom: '1px solid #e4e7e9',
     padding: '1em 1.2em 1em',
   },
   textArea: {
-    padding: '0.75em 1em',
-    marginTop: '0.4em',
     width: '100%',
     border: '0',
     resize: 'none',
     fontSize: '14px',
     fontFamily: 'Inter',
+    outline: 'none',
   },
   button: {
     padding: '0.56em',
@@ -47,7 +47,17 @@ const useStyles = makeStyles({
     marginTop: -12,
     marginLeft: -12,
   },
-});
+  textAreaContainer: {
+    display: 'flex',
+    marginTop: '0.4em',
+    padding: '0.48em 0.7em',
+    border: '2px solid transparent',
+  },
+  isTextareaFocused: {
+    borderColor: theme.palette.primary.main,
+    borderRadius: '4px',
+  },
+}));
 
 interface ChatInputProps {
   conversation: Conversation;
@@ -65,6 +75,7 @@ export default function ChatInput({ conversation, isChatWindowOpen }: ChatInputP
   const isValidMessage = /\S/.test(messageBody);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isTextareaFocused, setIsTextareaFocused] = useState(false);
 
   useEffect(() => {
     if (isChatWindowOpen) {
@@ -125,19 +136,27 @@ export default function ChatInput({ conversation, isChatWindowOpen }: ChatInputP
         variant="error"
         handleClose={() => setFileSendError(null)}
       />
-
-      <TextareaAutosize
-        rowsMin={1}
-        rowsMax={3}
-        className={classes.textArea}
-        aria-label="chat input"
-        placeholder="Write a message..."
-        onKeyPress={handleReturnKeyPress}
-        onChange={handleChange}
-        value={messageBody}
-        data-cy-chat-input
-        ref={textInputRef}
-      />
+      <div className={clsx(classes.textAreaContainer, { [classes.isTextareaFocused]: isTextareaFocused })}>
+        {/* 
+        Here we add the "isTextareaFocused" class when the user is focused on the TextareaAutosize component.
+        This helps to ensure a consistent appearance across all browsers. Adding padding to the TextareaAutosize
+        component does not work well in Firefox. See: https://github.com/twilio/twilio-video-app-react/issues/498
+        */}
+        <TextareaAutosize
+          rowsMin={1}
+          rowsMax={3}
+          className={classes.textArea}
+          aria-label="chat input"
+          placeholder="Write a message..."
+          onKeyPress={handleReturnKeyPress}
+          onChange={handleChange}
+          value={messageBody}
+          data-cy-chat-input
+          ref={textInputRef}
+          onFocus={() => setIsTextareaFocused(true)}
+          onBlur={() => setIsTextareaFocused(false)}
+        />
+      </div>
 
       <Grid container alignItems="flex-end" justify="flex-end" wrap="nowrap">
         {/* Since the file input element is invisible, we can hardcode an empty string as its value.

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     chatWindowContainer: {
       background: '#FFFFFF',
-      zIndex: 100,
+      zIndex: 9,
       display: 'flex',
       flexDirection: 'column',
       borderLeft: '1px solid #E4E7E9',

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -20,6 +20,7 @@ const useStyles = makeStyles((theme: Theme) =>
         left: 0,
         bottom: 0,
         right: 0,
+        zIndex: 100,
       },
     },
     hide: {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR fixes the styling of the chat input in firefox. The input now has a consistent appearance across all browsers. In Chrome and Safari, the appearance has not changed from how it looked previously. 

Firefox: 
![image](https://user-images.githubusercontent.com/12685223/117687458-0bab5580-b175-11eb-9ff7-41050f9ae51a.png)

To see what it looked like previously, see this issue: https://github.com/twilio/twilio-video-app-react/issues/498

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary