### PR TITLE
Use getSettings instead of getCapabilities to fix FF error

### DIFF
--- a/src/__mocks__/twilio-video.ts
+++ b/src/__mocks__/twilio-video.ts
@@ -14,7 +14,7 @@ const mockRoom = new MockRoom();
 class MockTrack extends EventEmitter {
   kind = '';
   stop = jest.fn();
-  mediaStreamTrack = { getCapabilities: () => ({ deviceId: 'mockDeviceId' }) };
+  mediaStreamTrack = { getSettings: () => ({ deviceId: 'mockDeviceId' }) };
 
   constructor(kind: string) {
     super();

--- a/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
+++ b/src/components/VideoProvider/useLocalTracks/useLocalTracks.ts
@@ -93,7 +93,7 @@ export default function useLocalTracks() {
           // in cases where the user's video is disabled.
           window.localStorage.setItem(
             SELECTED_VIDEO_INPUT_KEY,
-            newVideoTrack.mediaStreamTrack.getCapabilities().deviceId ?? ''
+            newVideoTrack.mediaStreamTrack.getSettings().deviceId ?? ''
           );
         }
         if (newAudioTrack) {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR fixes an issue where users are unable to acquire audio in Firefox due to an error. 

This PR removes the usage of `mediaStreamStrack.getCapabilities()` and replaces it with `mediaStreamStrack.getSettings()`. These functions are used to get the deviceID after a camera track is acquired. 

The error was due to the fact that `getCapabilities()` is not supported in Firefox. See the following browser compatibility tables:
https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getSettings
https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities

This PR works in desktop and mobile versions of Chrome, Firefox, and Safari.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary