### PR TITLE
fixed the passcode regex

### DIFF
--- a/src/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/src/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 const endpoint = process.env.REACT_APP_TOKEN_ENDPOINT || '/token';
 
 export function getPasscode() {
-  const match = window.location.search.match(/passcode=(.*)&?/);
+  const match = window.location.search.match(/[?&]passcode=([^&]+).*$/);
   const passcode = match ? match[1] : window.sessionStorage.getItem('passcode');
   return passcode;
 }


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

This fixes a bug with the regex fetching the passcode from the url: doesn't work if passcode is not the last parameter in the url. For example `?passcode=1234&name=User` would not work but `?name=User&passcode=1234` would work. I fixed this to make it work in all cases. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary