### PR TITLE
Add env variable to allow for disabling twilio recordings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ TWILIO_CONVERSATIONS_SERVICE_SID=IS00000000000000000000000000000000
 # Un-comment the following line to disable the Twilio Conversations functionality in the app. 
 # REACT_APP_DISABLE_TWILIO_CONVERSATIONS=true
 
+# Un-comment the following line to disable the Twilio Recordings functionality in the app. 
+# REACT_APP_DISABLE_TWILIO_RECORDINGS=true
+
 # Un-comment the following line to use a custom endpoint for obtaining tokens. Defaults to /token
 # REACT_APP_TOKEN_ENDPOINT=https://example.com/token
 

--- a/src/components/MenuBar/Menu/Menu.test.tsx
+++ b/src/components/MenuBar/Menu/Menu.test.tsx
@@ -55,9 +55,18 @@ describe('the Menu component', () => {
   });
 
   describe('the recording button', () => {
+    it('should not display when REACT_APP_DISABLE_TWILIO_RECORDINGS is true', () => {
+      process.env.REACT_APP_DISABLE_TWILIO_RECORDINGS = 'true';
+      const { getByText, queryByText } = render(<Menu />);
+      fireEvent.click(getByText('More'));
+
+      expect(queryByText('Start Recording')).toBeNull();
+    });
+
     describe('while recording is in progress', () => {
       beforeAll(() => {
         mockUseIsRecording.mockImplementation(() => true);
+        process.env.REACT_APP_DISABLE_TWILIO_RECORDINGS = 'false';
       });
 
       it('should display "Stop Recording"', () => {

--- a/src/components/MenuBar/Menu/Menu.tsx
+++ b/src/components/MenuBar/Menu/Menu.tsx
@@ -70,23 +70,25 @@ export default function Menu(props: { buttonClassName?: string }) {
           horizontal: 'center',
         }}
       >
-        {roomType !== 'peer-to-peer' && roomType !== 'go' && (
-          <MenuItem
-            disabled={isFetching}
-            onClick={() => {
-              setMenuOpen(false);
-              if (isRecording) {
-                updateRecordingRules(room!.sid, [{ type: 'exclude', all: true }]);
-              } else {
-                updateRecordingRules(room!.sid, [{ type: 'include', all: true }]);
-              }
-            }}
-            data-cy-recording-button
-          >
-            <IconContainer>{isRecording ? <StopRecordingIcon /> : <StartRecordingIcon />}</IconContainer>
-            <Typography variant="body1">{isRecording ? 'Stop' : 'Start'} Recording</Typography>
-          </MenuItem>
-        )}
+        {process.env.REACT_APP_DISABLE_TWILIO_RECORDINGS !== 'true' &&
+          roomType !== 'peer-to-peer' &&
+          roomType !== 'go' && (
+            <MenuItem
+              disabled={isFetching}
+              onClick={() => {
+                setMenuOpen(false);
+                if (isRecording) {
+                  updateRecordingRules(room!.sid, [{ type: 'exclude', all: true }]);
+                } else {
+                  updateRecordingRules(room!.sid, [{ type: 'include', all: true }]);
+                }
+              }}
+              data-cy-recording-button
+            >
+              <IconContainer>{isRecording ? <StopRecordingIcon /> : <StartRecordingIcon />}</IconContainer>
+              <Typography variant="body1">{isRecording ? 'Stop' : 'Start'} Recording</Typography>
+            </MenuItem>
+          )}
         {flipCameraSupported && (
           <MenuItem disabled={flipCameraDisabled} onClick={toggleFacingMode}>
             <IconContainer>


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This PR gives you the option to turn off the new recording functionality. I used similar logic to the REACT_APP_DISABLE_TWILIO_CONVERSATIONS env variable. Due to privacy concerns and not always wanting this enabled, it would be great to have this added configuration.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary