### PR TITLE
Video 6578 display all camera tracks

### DIFF
--- a/src/components/ChatProvider/index.tsx
+++ b/src/components/ChatProvider/index.tsx
@@ -72,7 +72,8 @@ export const ChatProvider: React.FC = ({ children }) => {
           window.chatConversation = newConversation;
           setConversation(newConversation);
         })
-        .catch(() => {
+        .catch(e => {
+          console.error(e);
           onError(new Error('There was a problem getting the Conversation associated with this room.'));
         });
     }

--- a/src/components/ChatProvider/index.tsx
+++ b/src/components/ChatProvider/index.tsx
@@ -32,7 +32,8 @@ export const ChatProvider: React.FC = ({ children }) => {
           window.chatClient = client;
           setChatClient(client);
         })
-        .catch(() => {
+        .catch(e => {
+          console.error(e);
           onError(new Error("There was a problem connecting to Twilio's conversation service."));
         });
     },

--- a/src/components/MainParticipantInfo/MainParticipantInfo.test.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.test.tsx
@@ -31,7 +31,7 @@ describe('the MainParticipantInfo component', () => {
 
   beforeEach(() => {
     mockUseVideoContext.mockImplementation(() => ({ room: { localParticipant: {} } }));
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     mockUseTrack.mockImplementation((track: any) => track);
     mockUseIsTrackSwitchedOff.mockImplementation(() => false);
   });
@@ -45,7 +45,7 @@ describe('the MainParticipantInfo component', () => {
   });
 
   it('should not render the AvatarIcon component when video tracks are published', () => {
-    mockUsePublications.mockImplementationOnce(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementationOnce(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>
     );
@@ -70,7 +70,7 @@ describe('the MainParticipantInfo component', () => {
 
   it('should not render the reconnecting UI when the user is connected', () => {
     mockUseParticipantIsReconnecting.mockImplementationOnce(() => false);
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>
     );
@@ -79,7 +79,7 @@ describe('the MainParticipantInfo component', () => {
 
   it('should render the reconnecting UI when the user is reconnecting', () => {
     mockUseParticipantIsReconnecting.mockImplementationOnce(() => true);
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>
     );
@@ -87,15 +87,15 @@ describe('the MainParticipantInfo component', () => {
   });
 
   it('should use the switchOff status of the screen share track when it is available', () => {
-    mockUsePublications.mockImplementationOnce(() => [{ trackName: 'screen' }, { trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementationOnce(() => [{ trackName: 'screen' }, { trackName: '', kind: 'video' }]);
     shallow(<MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>);
     expect(mockUseTrack).toHaveBeenCalledWith({ trackName: 'screen' });
   });
 
   it('should use the switchOff status of the camera track when the screen share track is not available', () => {
-    mockUsePublications.mockImplementationOnce(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementationOnce(() => [{ trackName: '', kind: 'video' }]);
     shallow(<MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>);
-    expect(mockUseTrack).toHaveBeenCalledWith({ trackName: 'camera-123456' });
+    expect(mockUseTrack).toHaveBeenCalledWith({ trackName: '', kind: 'video' });
   });
 
   it('should add "(You)" to the participants identity when they are the localParticipant', () => {
@@ -113,7 +113,7 @@ describe('the MainParticipantInfo component', () => {
   });
 
   it('should add "- Screen" to the participants identity when they are screen sharing', () => {
-    mockUsePublications.mockImplementationOnce(() => [{ trackName: 'screen' }, { trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementationOnce(() => [{ trackName: 'screen' }, { trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>
     );

--- a/src/components/MainParticipantInfo/MainParticipantInfo.test.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.test.tsx
@@ -113,7 +113,10 @@ describe('the MainParticipantInfo component', () => {
   });
 
   it('should add "- Screen" to the participants identity when they are screen sharing', () => {
-    mockUsePublications.mockImplementationOnce(() => [{ trackName: 'screen' }, { trackName: '', kind: 'video' }]);
+    mockUsePublications.mockImplementationOnce(() => [
+      { trackName: 'screen', kind: 'video' },
+      { trackName: '', kind: 'video' },
+    ]);
     const wrapper = shallow(
       <MainParticipantInfo participant={{ identity: 'mockIdentity' } as any}>mock children</MainParticipantInfo>
     );

--- a/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -157,7 +157,7 @@ export default function MainParticipantInfo({ participant, children }: MainParti
               {screenSharePublication && ' - Screen'}
             </Typography>
           </div>
-          <NetworkQualityLevel participant={localParticipant} />
+          <NetworkQualityLevel participant={participant} />
         </div>
         {isRecording && (
           <Tooltip

--- a/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -125,7 +125,7 @@ export default function MainParticipantInfo({ participant, children }: MainParti
   const isRemoteParticipantScreenSharing = screenShareParticipant && screenShareParticipant !== localParticipant;
 
   const publications = usePublications(participant);
-  const videoPublication = publications.find(p => p.trackName.includes('camera'));
+  const videoPublication = publications.find(p => !p.trackName.includes('screen') && p.kind === 'video');
   const screenSharePublication = publications.find(p => p.trackName.includes('screen'));
 
   const videoTrack = useTrack(screenSharePublication || videoPublication);

--- a/src/components/ParticipantInfo/ParticipantInfo.test.tsx
+++ b/src/components/ParticipantInfo/ParticipantInfo.test.tsx
@@ -6,6 +6,7 @@ import { shallow } from 'enzyme';
 import useIsTrackSwitchedOff from '../../hooks/useIsTrackSwitchedOff/useIsTrackSwitchedOff';
 import useParticipantIsReconnecting from '../../hooks/useParticipantIsReconnecting/useParticipantIsReconnecting';
 import usePublications from '../../hooks/usePublications/usePublications';
+import ScreenShareIcon from '../../icons/ScreenShareIcon';
 
 jest.mock('../../hooks/useParticipantNetworkQualityLevel/useParticipantNetworkQualityLevel', () => () => 4);
 jest.mock('../../hooks/usePublications/usePublications');
@@ -28,7 +29,7 @@ describe('the ParticipantInfo component', () => {
   });
 
   it('should not display the AvatarIcon component when a video track is published', () => {
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
         mock children
@@ -39,7 +40,7 @@ describe('the ParticipantInfo component', () => {
 
   it('should render the AvatarIcon component when the video track is switchedOff', () => {
     mockUseIsTrackSwitchedOff.mockImplementation(() => true);
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
         mock children
@@ -50,7 +51,7 @@ describe('the ParticipantInfo component', () => {
 
   it('should not render the reconnecting UI when the user is connected', () => {
     mockUseParticipantIsReconnecting.mockImplementationOnce(() => false);
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
         mock children
@@ -61,7 +62,7 @@ describe('the ParticipantInfo component', () => {
 
   it('should render the reconnecting UI when the user is reconnecting', () => {
     mockUseParticipantIsReconnecting.mockImplementationOnce(() => true);
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
         mock children
@@ -117,7 +118,7 @@ describe('the ParticipantInfo component', () => {
   });
 
   it('should render the PinIcon component when the participant is selected', () => {
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo onClick={() => {}} isSelected={true} participant={{ identity: 'mockIdentity' } as any}>
         mock children
@@ -127,7 +128,7 @@ describe('the ParticipantInfo component', () => {
   });
 
   it('should not render the PinIcon component when the participant is not selected', () => {
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
         mock children
@@ -136,9 +137,29 @@ describe('the ParticipantInfo component', () => {
     expect(wrapper.exists(PinIcon)).toBe(false);
   });
 
+  it('should render the ScreenShareIcon component when the participant is sharing their screen', () => {
+    mockUsePublications.mockImplementation(() => [{ trackName: 'screen', kind: 'video' }]);
+    const wrapper = shallow(
+      <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
+        mock children
+      </ParticipantInfo>
+    );
+    expect(wrapper.exists(ScreenShareIcon)).toBe(true);
+  });
+
+  it('should not render the ScreenShareIcon component when the participant is not sharing their screen', () => {
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
+    const wrapper = shallow(
+      <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
+        mock children
+      </ParticipantInfo>
+    );
+    expect(wrapper.exists(ScreenShareIcon)).toBe(false);
+  });
+
   it('should add "(You)" to the participants identity when they are the localParticipant', () => {
     mockUseIsTrackSwitchedOff.mockImplementation(() => false);
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo
         onClick={() => {}}
@@ -154,7 +175,7 @@ describe('the ParticipantInfo component', () => {
 
   it('should not add "(You)" to the participants identity when they are the localParticipant', () => {
     mockUseIsTrackSwitchedOff.mockImplementation(() => false);
-    mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456' }]);
+    mockUsePublications.mockImplementation(() => [{ trackName: '', kind: 'video' }]);
     const wrapper = shallow(
       <ParticipantInfo onClick={() => {}} isSelected={false} participant={{ identity: 'mockIdentity' } as any}>
         mock children

--- a/src/components/ParticipantInfo/ParticipantInfo.tsx
+++ b/src/components/ParticipantInfo/ParticipantInfo.tsx
@@ -147,7 +147,7 @@ export default function ParticipantInfo({
   const publications = usePublications(participant);
 
   const audioPublication = publications.find(p => p.kind === 'audio');
-  const videoPublication = publications.find(p => p.trackName.includes('camera'));
+  const videoPublication = publications.find(p => !p.trackName.includes('screen') && p.kind === 'video');
 
   const isVideoEnabled = Boolean(videoPublication);
   const isScreenShareEnabled = publications.find(p => p.trackName.includes('screen'));

--- a/src/components/ParticipantTracks/ParticipantTracks.test.tsx
+++ b/src/components/ParticipantTracks/ParticipantTracks.test.tsx
@@ -22,7 +22,7 @@ describe('the ParticipantTracks component', () => {
   it('should filter out any screen share publications', () => {
     mockUsePublications.mockImplementation(() => [
       { trackName: 'screen', trackSid: 0, kind: 'video' },
-      { trackName: 'camera-123456', trackSid: 1, kind: 'video' },
+      { trackName: '', trackSid: 1, kind: 'video' },
     ]);
     const wrapper = shallow(<ParticipantTracks participant={'mockParticipant' as any} />);
     expect(wrapper.find('Publication').length).toBe(1);
@@ -31,14 +31,14 @@ describe('the ParticipantTracks component', () => {
         .find('Publication')
         .at(0)
         .prop('publication')
-    ).toEqual({ trackName: 'camera-123456', trackSid: 1, kind: 'video' });
+    ).toEqual({ trackName: '', trackSid: 1, kind: 'video' });
   });
 
   describe('with enableScreenShare prop', () => {
     it('should filter out camera publications when a screen share publication is present', () => {
       mockUsePublications.mockImplementation(() => [
         { trackName: 'screen', trackSid: 0, kind: 'video' },
-        { trackName: 'camera-123456', trackSid: 1, kind: 'video' },
+        { trackName: '', trackSid: 1, kind: 'video' },
       ]);
       const wrapper = shallow(<ParticipantTracks participant={'mockParticipant' as any} enableScreenShare />);
       expect(wrapper.find('Publication').length).toBe(1);
@@ -51,7 +51,7 @@ describe('the ParticipantTracks component', () => {
     });
 
     it('should render camera publications when a screen share publication is absent', () => {
-      mockUsePublications.mockImplementation(() => [{ trackName: 'camera-123456', trackSid: 1, kind: 'video' }]);
+      mockUsePublications.mockImplementation(() => [{ trackName: '', trackSid: 1, kind: 'video' }]);
       const wrapper = shallow(<ParticipantTracks participant={'mockParticipant' as any} enableScreenShare />);
       expect(wrapper.find('Publication').length).toBe(1);
       expect(
@@ -59,7 +59,7 @@ describe('the ParticipantTracks component', () => {
           .find('Publication')
           .at(0)
           .prop('publication')
-      ).toEqual({ trackName: 'camera-123456', trackSid: 1, kind: 'video' });
+      ).toEqual({ trackName: '', trackSid: 1, kind: 'video' });
     });
   });
 });

--- a/src/components/ParticipantTracks/ParticipantTracks.tsx
+++ b/src/components/ParticipantTracks/ParticipantTracks.tsx
@@ -31,8 +31,11 @@ export default function ParticipantTracks({
   let filteredPublications;
 
   if (enableScreenShare && publications.some(p => p.trackName.includes('screen'))) {
-    filteredPublications = publications.filter(p => !p.trackName.includes('camera'));
+    // When displaying a screenshare track is allowed, and a screen share track exists,
+    // remove all video tracks without the name 'screen'.
+    filteredPublications = publications.filter(p => p.trackName.includes('screen') || p.kind !== 'video');
   } else {
+    // Else, remove all screenshare tracks
     filteredPublications = publications.filter(p => !p.trackName.includes('screen'));
   }
 

--- a/src/components/PreJoinScreens/DeviceSelectionScreen/LocalVideoPreview/LocalVideoPreview.test.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/LocalVideoPreview/LocalVideoPreview.test.tsx
@@ -16,7 +16,8 @@ describe('the LocalVideoPreview component', () => {
       return {
         localTracks: [
           {
-            name: 'camera-123456',
+            name: '',
+            kind: 'video',
             attach: jest.fn(),
             detach: jest.fn(),
             mediaStreamTrack: { getSettings: () => ({}) },

--- a/src/components/PreJoinScreens/DeviceSelectionScreen/LocalVideoPreview/LocalVideoPreview.tsx
+++ b/src/components/PreJoinScreens/DeviceSelectionScreen/LocalVideoPreview/LocalVideoPreview.tsx
@@ -57,7 +57,9 @@ export default function LocalVideoPreview({ identity }: { identity: string }) {
   const classes = useStyles();
   const { localTracks } = useVideoContext();
 
-  const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack;
+  const videoTrack = localTracks.find(
+    track => !track.name.includes('screen') && track.kind === 'video'
+  ) as LocalVideoTrack;
 
   return (
     <div className={classes.container}>

--- a/src/components/Publication/Publication.test.tsx
+++ b/src/components/Publication/Publication.test.tsx
@@ -9,7 +9,7 @@ const mockUseTrack = useTrack as jest.Mock<any>;
 describe('the Publication component', () => {
   describe('when track.kind is "video"', () => {
     it('should render a VideoTrack', () => {
-      mockUseTrack.mockImplementation(() => ({ kind: 'video', name: 'camera-123456' }));
+      mockUseTrack.mockImplementation(() => ({ kind: 'video', name: '' }));
       const wrapper = shallow(
         <Publication isLocalParticipant publication={'mockPublication' as any} participant={'mockParticipant' as any} />
       );
@@ -17,7 +17,7 @@ describe('the Publication component', () => {
       expect(wrapper.find('VideoTrack').length).toBe(1);
     });
 
-    it('should ignore the "isLocalParticipant" prop when track.name is not "camera"', () => {
+    it('should ignore the "isLocalParticipant" prop when track.name contains "screen"', () => {
       mockUseTrack.mockImplementation(() => ({ kind: 'video', name: 'screen-123456' }));
       const wrapper = shallow(
         <Publication isLocalParticipant publication={'mockPublication' as any} participant={'mockParticipant' as any} />
@@ -26,8 +26,8 @@ describe('the Publication component', () => {
       expect(wrapper.find({ isLocal: false }).length).toBe(1);
     });
 
-    it('should use the "isLocalParticipant" prop when track.name is "camera"', () => {
-      mockUseTrack.mockImplementation(() => ({ kind: 'video', name: 'camera-123456' }));
+    it('should use the "isLocalParticipant" prop when track.name does not contain "screen" and track.kind is "video"', () => {
+      mockUseTrack.mockImplementation(() => ({ kind: 'video', name: '' }));
       const wrapper = shallow(
         <Publication isLocalParticipant publication={'mockPublication' as any} participant={'mockParticipant' as any} />
       );

--- a/src/components/Publication/Publication.tsx
+++ b/src/components/Publication/Publication.tsx
@@ -31,7 +31,7 @@ export default function Publication({ publication, isLocalParticipant, videoOnly
         <VideoTrack
           track={track as IVideoTrack}
           priority={videoPriority}
-          isLocal={track.name.includes('camera') && isLocalParticipant}
+          isLocal={!track.name.includes('screen') && isLocalParticipant}
         />
       );
     case 'audio':

--- a/src/components/VideoProvider/index.tsx
+++ b/src/components/VideoProvider/index.tsx
@@ -81,7 +81,9 @@ export function VideoProvider({ options, children, onError = () => {} }: VideoPr
   useRestartAudioTrackOnDeviceChange(localTracks);
 
   const [isBackgroundSelectionOpen, setIsBackgroundSelectionOpen] = useState(false);
-  const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack | undefined;
+  const videoTrack = localTracks.find(track => !track.name.includes('screen') && track.kind === 'video') as
+    | LocalVideoTrack
+    | undefined;
   const [backgroundSettings, setBackgroundSettings] = useBackgroundSettings(videoTrack, room);
 
   return (

--- a/src/hooks/useFlipCameraToggle/useFlipCameraToggle.test.tsx
+++ b/src/hooks/useFlipCameraToggle/useFlipCameraToggle.test.tsx
@@ -13,7 +13,8 @@ const mockUseDevices = useDevices as jest.Mock<any>;
 const mockStreamSettings = { facingMode: 'user' };
 
 const mockVideoTrack = {
-  name: 'camera',
+  name: '',
+  kind: 'video',
   mediaStreamTrack: {
     getSettings: () => mockStreamSettings,
   },

--- a/src/hooks/useFlipCameraToggle/useFlipCameraToggle.tsx
+++ b/src/hooks/useFlipCameraToggle/useFlipCameraToggle.tsx
@@ -8,7 +8,9 @@ import useVideoContext from '../useVideoContext/useVideoContext';
 export default function useFlipCameraToggle() {
   const { localTracks } = useVideoContext();
   const [supportsFacingMode, setSupportsFacingMode] = useState(false);
-  const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack | undefined;
+  const videoTrack = localTracks.find(track => !track.name.includes('screen') && track.kind === 'video') as
+    | LocalVideoTrack
+    | undefined;
   const mediaStreamTrack = useMediaStreamTrack(videoTrack);
   const { videoInputDevices } = useDevices();
 

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.test.tsx
@@ -7,9 +7,10 @@ import { LocalParticipant } from 'twilio-video';
 jest.mock('../useVideoContext/useVideoContext');
 const mockUseVideoContext = useVideoContext as jest.Mock<any>;
 
-function getMockTrack(name: string, deviceId?: string) {
+function getMockTrack(kind: string, deviceId?: string) {
   return {
-    name,
+    name: '',
+    kind,
     mediaStreamTrack: {
       getSettings: () => ({
         deviceId,
@@ -21,7 +22,7 @@ function getMockTrack(name: string, deviceId?: string) {
 describe('the useLocalVideoToggle hook', () => {
   it('should return true when a localVideoTrack exists', () => {
     mockUseVideoContext.mockImplementation(() => ({
-      localTracks: [getMockTrack('camera-123456')],
+      localTracks: [getMockTrack('video')],
       room: { localParticipant: {} },
     }));
 
@@ -31,7 +32,7 @@ describe('the useLocalVideoToggle hook', () => {
 
   it('should return false when a localVideoTrack does not exist', () => {
     mockUseVideoContext.mockImplementation(() => ({
-      localTracks: [getMockTrack('microphone')],
+      localTracks: [getMockTrack('audio')],
       room: { localParticipant: {} },
     }));
 
@@ -44,7 +45,7 @@ describe('the useLocalVideoToggle hook', () => {
       const mockRemoveLocalVideoTrack = jest.fn();
 
       mockUseVideoContext.mockImplementation(() => ({
-        localTracks: [getMockTrack('camera')],
+        localTracks: [getMockTrack('video')],
         room: { localParticipant: null },
         removeLocalVideoTrack: mockRemoveLocalVideoTrack,
       }));
@@ -56,7 +57,7 @@ describe('the useLocalVideoToggle hook', () => {
 
     it('should call localParticipant.unpublishTrack when a localVideoTrack and localParticipant exists', () => {
       const mockLocalTrack = {
-        ...getMockTrack('camera-123456'),
+        ...getMockTrack('video'),
         stop: jest.fn(),
       };
 

--- a/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
+++ b/src/hooks/useLocalVideoToggle/useLocalVideoToggle.tsx
@@ -5,7 +5,9 @@ import useVideoContext from '../useVideoContext/useVideoContext';
 export default function useLocalVideoToggle() {
   const { room, localTracks, getLocalVideoTrack, removeLocalVideoTrack, onError } = useVideoContext();
   const localParticipant = room?.localParticipant;
-  const videoTrack = localTracks.find(track => track.name.includes('camera')) as LocalVideoTrack;
+  const videoTrack = localTracks.find(
+    track => !track.name.includes('screen') && track.kind === 'video'
+  ) as LocalVideoTrack;
   const [isPublishing, setIspublishing] = useState(false);
 
   const toggleVideoEnabled = useCallback(() => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -24,3 +24,6 @@ class LocalStorage {
 }
 
 Object.defineProperty(window, 'localStorage', { value: new LocalStorage() });
+
+// This is to suppress the "Platform browser has already been set." warnings from the video-processors library
+jest.mock('@twilio/video-processors', () => ({}));


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [AHOYAPPS-6578](https://issues.corp.twilio.com/browse/AHOYAPPS-6578)

### Description

This PR addresses an interoperability issue between this app and Twilio's iOS and Android quickstart apps. The issue was that this app was not displaying video tracks because the tracks were not correctly labeled. If the track name did not include 'camera' (all lowercase), then the track would not be displayed. This means that unlabeled tracks, or tracks labeled as 'Camera' (uppercase 'C') would not be displayed. 

This PR removes the requirement that video tracks have a name in order to be displayed. Screen share tracks must still contain the word 'screen' in order to be treated as screen share tracks. 

Additionally, this PR makes the following changes: 
- Adds error logging for conversations
- Fixes issue with the MainParticipant displaying the network quality for the LocalParticipant. 
- Suppresses tfjs warnings during tests. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary