### PR TITLE
Address Landscape/Portrait UI issues

### DIFF
--- a/src/hooks/useHeight/useHeight.test.tsx
+++ b/src/hooks/useHeight/useHeight.test.tsx
@@ -3,39 +3,105 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import useHeight from './useHeight';
 
 describe('the useHeight hook', () => {
-  it('should return window.innerHeight', () => {
-    // @ts-ignore
-    window.innerHeight = 100;
-    const { result } = renderHook(useHeight);
-    expect(result.current).toBe('100px');
+  describe('device was rotated', () => {
+    it('returns the updated height', () => {
+      const mockScrollTo = jest.fn((x: number, y: number) => undefined);
+      Object.defineProperty(window, 'innerHeight', { writable: true, value: 500 });
+      Object.defineProperty(window, 'scrollTo', { writable: true, value: mockScrollTo });
+      Object.defineProperty(window, 'visualViewport', {
+        writable: true,
+        value: {
+          height: 500,
+          onresize: undefined,
+          width: 400,
+        },
+      });
 
-    act(() => {
-      // @ts-ignore
-      window.innerHeight = 150;
-      window.dispatchEvent(new Event('resize'));
+      const { result, rerender } = renderHook(useHeight);
+
+      expect(result.current).toBe('500px');
+
+      act(() => {
+        Object.defineProperty(window, 'innerHeight', { writable: true, value: 400 });
+        Object.defineProperty(window, 'visualViewport', {
+          writable: true,
+          value: {
+            ...window.visualViewport,
+            height: 400,
+            width: 500,
+          },
+        });
+
+        if (window.visualViewport.onresize) {
+          window.visualViewport.onresize(new UIEvent('resize'));
+        }
+      });
+
+      rerender();
+
+      expect(result.current).toBe('400px');
+      expect(mockScrollTo).toHaveBeenCalledWith(0, 0);
     });
+  });
 
-    expect(result.current).toBe('150px');
+  describe('device was NOT rotated', () => {
+    describe('NOT isMobile', () => {
+      it('returns the current height', () => {
+        const mockScrollTo = jest.fn((x: number, y: number) => undefined);
+        Object.defineProperty(window, 'innerHeight', { writable: true, value: 500 });
+        Object.defineProperty(window, 'scrollTo', { writable: true, value: mockScrollTo });
+        Object.defineProperty(window, 'visualViewport', {
+          writable: true,
+          value: {
+            height: 500,
+            onresize: undefined,
+            width: 400,
+          },
+        });
+
+        const { result, rerender } = renderHook(useHeight);
+
+        expect(result.current).toBe('500px');
+
+        act(() => {
+          if (window.visualViewport.onresize) {
+            window.visualViewport.onresize(new UIEvent('resize'));
+          }
+        });
+
+        rerender();
+
+        expect(result.current).toBe('500px');
+        expect(mockScrollTo).not.toHaveBeenCalledWith(0, 0);
+      });
+    });
   });
 
   it('should take window.visualViewport.scale into account', () => {
-    // @ts-ignore
-    window.innerHeight = 100;
-
-    // @ts-ignore
-    window.visualViewport = {
-      scale: 2,
-    };
-
-    const { result } = renderHook(useHeight);
-    expect(result.current).toBe('200px');
-
-    act(() => {
-      // @ts-ignore
-      window.innerHeight = 150;
-      window.dispatchEvent(new Event('resize'));
+    Object.defineProperty(window, 'innerHeight', { writable: true, value: 500 });
+    Object.defineProperty(window, 'visualViewport', {
+      writable: true,
+      value: {
+        height: 500,
+        onresize: undefined,
+        scale: 2,
+        width: 400,
+      },
     });
 
-    expect(result.current).toBe('300px');
+    const { result, rerender } = renderHook(useHeight);
+
+    expect(result.current).toBe('1000px');
+
+    act(() => {
+      Object.defineProperty(window, 'innerHeight', { writable: true, value: 750 });
+      if (window.visualViewport.onresize) {
+        window.visualViewport.onresize(new UIEvent('resize'));
+      }
+    });
+
+    rerender();
+
+    expect(result.current).toBe('1500px');
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,11 @@ declare module 'twilio-video' {
 
 declare global {
   interface Window {
-    visualViewport?: {
+    visualViewport: {
+      height: number;
+      onresize: ((this: VisualViewport, ev: UIEvent) => any) | null;
       scale: number;
+      width: number;
     };
   }
 


### PR DESCRIPTION
Remove reliance on event listeners in favor of window.visualViewport.onresize. This fixes the issue in Chrome where height got stuck after rotating back to portrait: #604. Reference:  https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/onresize

Additionally, ensure view is scrolled to top when rotated. This fixes sporadic issues where `window.scrollY` had a nonzero value after rotating (without touching the screen). This seems to happen more often on older/slower devices. Scrolling to the top should fix these cases.

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Moves addEventListener calls to visualViewport object, because this object has the 'resize' property they should be listening for. Offers a solution to https://github.com/twilio/twilio-video-app-react/issues/604. Please see screenshots in the issue for description. After this change I no longer saw the view getting stuck when switching back to Portrait view.
## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary