### PR TITLE
Handle screenshare in grid mode

### DIFF
--- a/src/components/Room/Room.test.tsx
+++ b/src/components/Room/Room.test.tsx
@@ -26,11 +26,8 @@ const mockUseVideoContext = useVideoContext as jest.Mock<any>;
 
 const mockToggleChatWindow = jest.fn();
 const mockOpenBackgroundSelection = jest.fn();
-
 mockUseChatContext.mockImplementation(() => ({ setIsChatWindowOpen: mockToggleChatWindow }));
-mockUseVideoContext.mockImplementation(() => ({
-  setIsBackgroundSelectionOpen: mockOpenBackgroundSelection,
-}));
+mockUseVideoContext.mockImplementation(() => ({ setIsBackgroundSelectionOpen: mockOpenBackgroundSelection }));
 mockUseAppState.mockImplementation(() => ({ isGridModeActive: false }));
 
 describe('the Room component', () => {

--- a/src/components/Room/Room.tsx
+++ b/src/components/Room/Room.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import clsx from 'clsx';
 import { makeStyles, Theme, useMediaQuery, useTheme } from '@material-ui/core';
 import ChatWindow from '../ChatWindow/ChatWindow';
@@ -11,6 +11,8 @@ import { ParticipantAudioTracks } from '../ParticipantAudioTracks/ParticipantAud
 import { GridView } from '../GridView/GridView';
 import { MobileGridView } from '../MobileGridView/MobileGridView';
 import { useAppState } from '../../state';
+import useScreenShareParticipant from '../../hooks/useScreenShareParticipant/useScreenShareParticipant';
+import { Participant, LocalParticipant, RemoteParticipant, Room as IRoom } from 'twilio-video';
 
 const useStyles = makeStyles((theme: Theme) => {
   const totalMobileSidebarHeight = `${theme.sidebarMobileHeight +
@@ -32,13 +34,30 @@ const useStyles = makeStyles((theme: Theme) => {
   };
 });
 
+export function useSetCollaborationViewOnScreenShare(
+  screenShareParticipant: Participant | undefined,
+  room: IRoom | null,
+  setIsGridModeActive: React.Dispatch<React.SetStateAction<boolean>>
+) {
+  useEffect(() => {
+    if (screenShareParticipant && screenShareParticipant !== room!.localParticipant) {
+      setIsGridModeActive(false);
+    }
+  }, [screenShareParticipant, setIsGridModeActive, room]);
+}
+
 export default function Room() {
   const classes = useStyles();
   const { isChatWindowOpen } = useChatContext();
-  const { isBackgroundSelectionOpen } = useVideoContext();
-  const { isGridModeActive } = useAppState();
+  const { isBackgroundSelectionOpen, room } = useVideoContext();
+  const { isGridModeActive, setIsGridModeActive } = useAppState();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const screenShareParticipant = useScreenShareParticipant();
+
+  // Here we switch to collaboration view when a participant starts sharing their screen, but
+  // the user is still free to switch back to grid mode.
+  useSetCollaborationViewOnScreenShare(screenShareParticipant, room, setIsGridModeActive);
 
   return (
     <div

--- a/src/components/Room/Room.tsx
+++ b/src/components/Room/Room.tsx
@@ -1,18 +1,18 @@
 import React, { useEffect } from 'react';
-import clsx from 'clsx';
-import { makeStyles, Theme, useMediaQuery, useTheme } from '@material-ui/core';
-import ChatWindow from '../ChatWindow/ChatWindow';
-import ParticipantList from '../ParticipantList/ParticipantList';
-import MainParticipant from '../MainParticipant/MainParticipant';
 import BackgroundSelectionDialog from '../BackgroundSelectionDialog/BackgroundSelectionDialog';
-import useChatContext from '../../hooks/useChatContext/useChatContext';
-import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
-import { ParticipantAudioTracks } from '../ParticipantAudioTracks/ParticipantAudioTracks';
+import ChatWindow from '../ChatWindow/ChatWindow';
+import clsx from 'clsx';
 import { GridView } from '../GridView/GridView';
 import { MobileGridView } from '../MobileGridView/MobileGridView';
+import MainParticipant from '../MainParticipant/MainParticipant';
+import { makeStyles, Theme, useMediaQuery, useTheme } from '@material-ui/core';
+import { Participant, Room as IRoom } from 'twilio-video';
+import { ParticipantAudioTracks } from '../ParticipantAudioTracks/ParticipantAudioTracks';
+import ParticipantList from '../ParticipantList/ParticipantList';
 import { useAppState } from '../../state';
+import useChatContext from '../../hooks/useChatContext/useChatContext';
 import useScreenShareParticipant from '../../hooks/useScreenShareParticipant/useScreenShareParticipant';
-import { Participant, LocalParticipant, RemoteParticipant, Room as IRoom } from 'twilio-video';
+import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
 
 const useStyles = makeStyles((theme: Theme) => {
   const totalMobileSidebarHeight = `${theme.sidebarMobileHeight +


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-10095](https://issues.corp.twilio.com/browse/VIDEO-10095)

### Description

This PR adds some logic to the app which switches the user to the Collaboration View when a remote participant (but not the local participant) starts to share their screen. Without this, a user using Grid View would not know that someone else is sharing their screen. Once the user has been automatically switched over to Grid View, they are free to switch back to Collaboration View. 

This is the same behavior as what is already implemented in the iOS Video App: https://github.com/twilio/twilio-video-app-ios/blob/67b8494a50eb48568b966aa9cf4c5dea2d327e61/VideoApp/VideoApp/SwiftUI/Screens/Room/RoomViewModel.swift#L88-L118

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary