### PR TITLE
Video 10096 persist grid settings

### DIFF
--- a/src/components/DeviceSelectionDialog/AudioInputList/AudioInputList.test.tsx
+++ b/src/components/DeviceSelectionDialog/AudioInputList/AudioInputList.test.tsx
@@ -77,7 +77,7 @@ describe('the AudioInputList component', () => {
   it('should save the deviceId in localStorage when the audio input device is changed', () => {
     mockUseDevices.mockImplementation(() => ({ audioInputDevices: [mockDevice, mockDevice] }));
     const wrapper = shallow(<AudioInputList />);
-    expect(window.localStorage.getItem(SELECTED_AUDIO_INPUT_KEY)).toBe(undefined);
+    expect(window.localStorage.getItem(SELECTED_AUDIO_INPUT_KEY)).toBe(null);
     wrapper.find(Select).simulate('change', { target: { value: 'mockDeviceID' } });
     expect(window.localStorage.getItem(SELECTED_AUDIO_INPUT_KEY)).toBe('mockDeviceID');
   });

--- a/src/components/DeviceSelectionDialog/VideoInputList/VideoInputList.test.tsx
+++ b/src/components/DeviceSelectionDialog/VideoInputList/VideoInputList.test.tsx
@@ -84,7 +84,7 @@ describe('the VideoInputList component', () => {
   it('should save the deviceId in localStorage when the video input device is changed', () => {
     mockUseDevices.mockImplementation(() => ({ videoInputDevices: [mockDevice, mockDevice] }));
     const wrapper = shallow(<VideoInputList />);
-    expect(window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY)).toBe(undefined);
+    expect(window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY)).toBe(null);
     wrapper.find(Select).simulate('change', { target: { value: 'mockDeviceID' } });
     expect(window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY)).toBe('mockDeviceID');
   });

--- a/src/components/VideoProvider/useBackgroundSettings/useBackgroundSettings.ts
+++ b/src/components/VideoProvider/useBackgroundSettings/useBackgroundSettings.ts
@@ -1,5 +1,5 @@
 import { LocalVideoTrack, Room } from 'twilio-video';
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { SELECTED_BACKGROUND_SETTINGS_KEY } from '../../../constants';
 import {
   GaussianBlurBackgroundProcessor,
@@ -40,6 +40,7 @@ import PlantThumb from '../../../images/thumb/Plant.jpg';
 import SanFrancisco from '../../../images/SanFrancisco.jpg';
 import SanFranciscoThumb from '../../../images/thumb/SanFrancisco.jpg';
 import { Thumbnail } from '../../BackgroundSelectionDialog/BackgroundThumbnail/BackgroundThumbnail';
+import { useLocalStorageState } from '../../../hooks/useLocalStorageState/useLocalStorageState';
 
 export interface BackgroundSettings {
   type: Thumbnail;
@@ -130,10 +131,10 @@ let blurProcessor: GaussianBlurBackgroundProcessor;
 let virtualBackgroundProcessor: VirtualBackgroundProcessor;
 
 export default function useBackgroundSettings(videoTrack: LocalVideoTrack | undefined, room?: Room | null) {
-  const [backgroundSettings, setBackgroundSettings] = useState<BackgroundSettings>(() => {
-    const localStorageSettings = window.localStorage.getItem(SELECTED_BACKGROUND_SETTINGS_KEY);
-    return localStorageSettings ? JSON.parse(localStorageSettings) : { type: 'none', index: 0 };
-  });
+  const [backgroundSettings, setBackgroundSettings] = useLocalStorageState<BackgroundSettings>(
+    SELECTED_BACKGROUND_SETTINGS_KEY,
+    { type: 'none', index: 0 }
+  );
 
   const removeProcessor = useCallback(() => {
     if (videoTrack && videoTrack.processor) {
@@ -187,7 +188,6 @@ export default function useBackgroundSettings(videoTrack: LocalVideoTrack | unde
       }
     };
     handleProcessorChange();
-    window.localStorage.setItem(SELECTED_BACKGROUND_SETTINGS_KEY, JSON.stringify(backgroundSettings));
   }, [backgroundSettings, videoTrack, room, addProcessor, removeProcessor]);
 
   return [backgroundSettings, setBackgroundSettings] as const;

--- a/src/hooks/useLocalStorageState/useLocalStorageState.test.ts
+++ b/src/hooks/useLocalStorageState/useLocalStorageState.test.ts
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useLocalStorageState } from './useLocalStorageState';
+
+describe('the useLocalStorageState hook', () => {
+  beforeEach(window.localStorage.clear);
+
+  it('should return initialState when nothing is stored in localStorage', () => {
+    const { result } = renderHook(() => useLocalStorageState('test-key', 'initialValue'));
+    expect(result.current[0]).toBe('initialValue');
+  });
+
+  it('should return the value from localStorage when it exists', () => {
+    window.localStorage.setItem('test-key', '"localStorageValue"');
+    const { result } = renderHook(() => useLocalStorageState('test-key', 'initialValue'));
+    expect(result.current[0]).toBe('localStorageValue');
+  });
+
+  it('should set a value in localStorage when the state is updated', () => {
+    const { result } = renderHook(() => useLocalStorageState('test-key', 'initialValue'));
+    act(() => {
+      result.current[1]('test-value');
+    });
+    expect(window.localStorage.getItem('test-key')).toBe('"test-value"');
+  });
+});

--- a/src/hooks/useLocalStorageState/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState/useLocalStorageState.ts
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+
+export function useLocalStorageState<T = undefined>(
+  key: string,
+  initialState: T | undefined
+): [T, React.Dispatch<React.SetStateAction<T | undefined>>];
+export function useLocalStorageState<T>(key: string, initialState: T) {
+  const [value, setValue] = useState(() => {
+    const item = window.localStorage.getItem(key);
+    if (item !== null) {
+      return JSON.parse(item) as T;
+    } else {
+      return initialState;
+    }
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }, [value]);
+
+  return [value, setValue] as const;
+}

--- a/src/hooks/useLocalStorageState/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState/useLocalStorageState.ts
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from 'react';
 
+/* This hook is like a useState() hook, but it will store the state in LocalStorage.
+   If a value exists in LocalStorage, it will be returned as the initial value when
+   this hook is run for the first time. Because this hook uses LocalStorage, it can 
+   only use values that can be serialized to and from JSON.
+*/
+
 export function useLocalStorageState<T = undefined>(
   key: string,
   initialState: T | undefined
@@ -16,7 +22,7 @@ export function useLocalStorageState<T>(key: string, initialState: T) {
 
   useEffect(() => {
     window.localStorage.setItem(key, JSON.stringify(value));
-  }, [value]);
+  }, [key, value]);
 
   return [value, setValue] as const;
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -11,7 +11,7 @@ class LocalStorage {
   store = {} as { [key: string]: string };
 
   getItem(key: string) {
-    return this.store[key];
+    return this.store[key] ? this.store[key] : null;
   }
 
   setItem(key: string, value: string) {

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -6,6 +6,7 @@ import useActiveSinkId from './useActiveSinkId/useActiveSinkId';
 import useFirebaseAuth from './useFirebaseAuth/useFirebaseAuth';
 import usePasscodeAuth from './usePasscodeAuth/usePasscodeAuth';
 import { User } from 'firebase';
+import { useLocalStorageState } from '../hooks/useLocalStorageState/useLocalStorageState';
 
 export interface StateContextType {
   error: TwilioError | Error | null;
@@ -42,11 +43,11 @@ export const StateContext = createContext<StateContextType>(null!);
 export default function AppStateProvider(props: React.PropsWithChildren<{}>) {
   const [error, setError] = useState<TwilioError | null>(null);
   const [isFetching, setIsFetching] = useState(false);
-  const [isGridModeActive, setIsGridModeActive] = useState(false);
+  const [isGridModeActive, setIsGridModeActive] = useLocalStorageState('grid-mode-active-key', false);
   const [activeSinkId, setActiveSinkId] = useActiveSinkId();
   const [settings, dispatchSetting] = useReducer(settingsReducer, initialSettings);
   const [roomType, setRoomType] = useState<RoomType>();
-  const [maxGridParticipants, setMaxGridParticipants] = useState(25);
+  const [maxGridParticipants, setMaxGridParticipants] = useLocalStorageState('max-grid-participants-key', 25);
 
   let contextValue = {
     error,

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -4,9 +4,9 @@ import { TwilioError } from 'twilio-video';
 import { settingsReducer, initialSettings, Settings, SettingsAction } from './settings/settingsReducer';
 import useActiveSinkId from './useActiveSinkId/useActiveSinkId';
 import useFirebaseAuth from './useFirebaseAuth/useFirebaseAuth';
+import { useLocalStorageState } from '../hooks/useLocalStorageState/useLocalStorageState';
 import usePasscodeAuth from './usePasscodeAuth/usePasscodeAuth';
 import { User } from 'firebase';
-import { useLocalStorageState } from '../hooks/useLocalStorageState/useLocalStorageState';
 
 export interface StateContextType {
   error: TwilioError | Error | null;


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-10096](https://issues.corp.twilio.com/browse/VIDEO-10096)

### Description

This PR updates the app so that the settings related to Grid Mode are persisted between visits (using local storage). A new hook, `useLocalStorageState` was created so that we don't have to duplicate the same local storage local throughout the app. This hook was also added to the `useBackgroundSettings` hook to simplify it a little.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary