### PR TITLE
Update CSS for mirroring local video

### DIFF
--- a/src/components/VideoTrack/VideoTrack.test.tsx
+++ b/src/components/VideoTrack/VideoTrack.test.tsx
@@ -61,7 +61,7 @@ describe('the VideoTrack component', () => {
 
   it('should flip the video horizontally if the track is local', () => {
     const { container } = render(<VideoTrack track={mockTrack} isLocal />);
-    expect(container.querySelector('video')!.style.transform).toEqual('rotateY(180deg)');
+    expect(container.querySelector('video')!.style.transform).toEqual('scaleX(-1)');
   });
 
   it('should not flip the video horizontally if the track is the local rear-facing camera', () => {

--- a/src/components/VideoTrack/VideoTrack.tsx
+++ b/src/components/VideoTrack/VideoTrack.tsx
@@ -46,7 +46,7 @@ export default function VideoTrack({ track, isLocal, priority }: VideoTrackProps
   // The local video track is mirrored if it is not facing the environment.
   const isFrontFacing = mediaStreamTrack?.getSettings().facingMode !== 'environment';
   const style = {
-    transform: isLocal && isFrontFacing ? 'rotateY(180deg)' : '',
+    transform: isLocal && isFrontFacing ? 'scaleX(-1)' : '',
     objectFit: isPortrait || track.name.includes('screen') ? ('contain' as const) : ('cover' as const),
   };
 


### PR DESCRIPTION
This helps to workaround a Safari CSS issue related to transforms

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-9871](https://issues.corp.twilio.com/browse/VIDEO-9871)

### Description

This PR changes the way that the local video track is mirrored. This change is made to help an issue that is experienced in Desktop Safari where the local video track sometimes appears to be black.

This changes the CSS:
`transform: rotateY(180deg)`
Which computes to (as seen in the 'Computed' tab in DevTools): 
`transform: matrix3d(-1, 0, -1.2246467991473532e-16, 0, 0, 1, 0, 0, 1.2246467991473532e-16, 0, -1, 0, 0, 0, 0, 1);`

to:
`transform: scaleX(-1)`
Which computes to:
`matrix(-1, 0, 0, 1, 0, 0)`

I'm not exactly sure why this workaround helps, but it may have something to do with the fact that `scaleX(-1)` results in a simpler 2d transformation, instead of the more complicated 3d transform that results from `rotateY(180deg)`. I'm guessing that Safari has an easier time with the simple 2d transform. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary