### PR TITLE
Fix memory leak in AudioLevelIndicator

### DIFF
--- a/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
+++ b/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
@@ -22,7 +22,12 @@ export function initializeAnalyser(stream: MediaStream) {
 
   // Here we provide a way for the audioContext to be closed.
   // Closing the audioContext allows the unused audioSource to be garbage collected.
-  stream.addEventListener('cleanup', () => audioContext.close());
+
+  stream.addEventListener('cleanup', () => {
+    if (audioContext.state !== 'closed') {
+      audioContext.close();
+    }
+  });
 
   return analyser;
 }

--- a/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
+++ b/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
@@ -9,10 +9,9 @@ const getUniqueClipId = () => clipId++;
 
 // @ts-ignore
 const AudioContext = window.AudioContext || window.webkitAudioContext;
-let audioContext: AudioContext;
 
 export function initializeAnalyser(stream: MediaStream) {
-  audioContext = audioContext || new AudioContext();
+  const audioContext = new AudioContext(); // Create a new audioContext for each audio indicator
   const audioSource = audioContext.createMediaStreamSource(stream);
 
   const analyser = audioContext.createAnalyser();
@@ -20,6 +19,11 @@ export function initializeAnalyser(stream: MediaStream) {
   analyser.fftSize = 256;
 
   audioSource.connect(analyser);
+
+  // Here we provide a way for the audioContext to be closed.
+  // Closing the audioContext allows the unused audioSource to be garbage collected.
+  stream.addEventListener('cleanup', () => audioContext.close());
+
   return analyser;
 }
 
@@ -40,7 +44,10 @@ function AudioLevelIndicator({ audioTrack, color = 'white' }: { audioTrack?: Aud
       // we stop the cloned track that is stored in 'newMediaStream'. It is important that we stop
       // all tracks when they are not in use. Browsers like Firefox don't let you create a new stream
       // from a new audio device while the active audio device still has active tracks.
-      const stopAllMediaStreamTracks = () => newMediaStream.getTracks().forEach(track => track.stop());
+      const stopAllMediaStreamTracks = () => {
+        newMediaStream.getTracks().forEach(track => track.stop());
+        newMediaStream.dispatchEvent(new Event('cleanup')); // Stop the audioContext
+      };
       audioTrack.on('stopped', stopAllMediaStreamTracks);
 
       const reinitializeAnalyser = () => {

--- a/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
+++ b/src/components/AudioLevelIndicator/AudioLevelIndicator.tsx
@@ -22,7 +22,6 @@ export function initializeAnalyser(stream: MediaStream) {
 
   // Here we provide a way for the audioContext to be closed.
   // Closing the audioContext allows the unused audioSource to be garbage collected.
-
   stream.addEventListener('cleanup', () => {
     if (audioContext.state !== 'closed') {
       audioContext.close();


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-10214](https://issues.corp.twilio.com/browse/VIDEO-10214)

### Description

This PR fixes an issue where the AudioLevelIndicator can cause a memory leak after it is mounted/unmounted many times. 

To see the issue, join a room, and run this code in the console which will repeatedly click the "Mute Audio" button:
```
var intervalId = setInterval(() => document.querySelector('[data-cy-audio-toggle]').click(), 10);
```

To stop this, just clear the interval id:
```
clearInterval(intervalId);
```

As the local audio track is repeatedly muted and unmuted, it will cause the AudioLevelIndicator to turn on and off. While this happens, you should see the memory footprint for the tab start to grow drastically (use Chrome's task manager to see the memory usage):

<img width="568" alt="image" src="https://user-images.githubusercontent.com/12685223/173882700-ee513442-78e6-4c43-b812-1f663a3202d6.png">

Also, you can see the memory leak if you take a heap snapshot and search for classes with "audio" in their name:
![image](https://user-images.githubusercontent.com/12685223/173882932-a13a03a3-9128-411a-845a-56dd6e8a582d.png)

You'll see that there's a huge number of `MediaStreamsAudioSourceNode` classes.

This the fix in the PR, you will no longer see 1) the memory footprint grow, or 2) the large amount of `MediaStreamsAudioSourceNode` classes in the heap.

This memory leak was caused by the fact that all AudioLevelIndicators used to share a single AudioContext. Because of this, all MediaStreamsAudioSourceNodes that were created could not be garbage collected because the single AudioContext instance was never closed. 

This this PR, each AudioLevelIndicator now uses their own AudioContext instance, which is then closed when it is no longer needed. As a result, all resources used by the AudioLevelIndicator are now appropriately garbage collected. 

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary