### PR TITLE
Store gcloud service account credentials in proper JSON format.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
 
       - run: echo $CIRCLE_TAG > build/version.txt
 
-      - run: gcloud secrets versions access latest --secret=firebase-admin-credentials > server/serviceAccountKey.json
+      - run: gcloud secrets versions access latest --secret=firebase-admin-credentials | sed 's/^[0-9a-f]*$//' > server/serviceAccountKey.json
 
       - run: gcloud app deploy -q
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.1 (January 10, 2023)
+
+## Changes
+
+- Modified CircleCI deploy script to store gcloud service account credentials in proper JSON format.
+
 ## 0.9.0 (November 23, 2022)
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twilio-video-app-react",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "twilio-video-app-react",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-video-app-react",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

For some reason, when we download the service account credentials, it is stored in the following format:
```
{
  ...
}

some-hex-number
```
This results in the application server's JSON parser failing to parse the credentials. So, this PR fixes the problem by removing the hexadecimal number from the output.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary